### PR TITLE
Fixes many broken links.

### DIFF
--- a/src/content/learning/debugging-workers.md
+++ b/src/content/learning/debugging-workers.md
@@ -48,7 +48,7 @@ Received new request to url: https://example.com/
 
 Inserting `console.log` lines throughout your code can help you understand the state of your application in various stages until you reach the desired output.
 
-You can customize how `wrangler dev` works to fit your needs: see [the docs](/tooling/wrangler/commands/#dev-alpha-) for available configuration options.
+You can customize how `wrangler dev` works to fit your needs: see [the docs](/reference/wrangler-cli/commands#dev-alpha) for available configuration options.
 
 --------------------------------
 
@@ -87,7 +87,7 @@ $ wrangler tail | jq .event.request.url
 "https://www.bytesized.xyz/page-data/app-data.json"
 ```
 
-You can customize how `wrangler tail` works to fit your needs: see [the docs](/tooling/wrangler/commands/#tail) for available configuration options.
+You can customize how `wrangler tail` works to fit your needs: see [the docs](/reference/wrangler-cli/commands#tail) for available configuration options.
 
 --------------------------------
 
@@ -100,9 +100,9 @@ When a Worker running in production has an error that prevents it from returning
 | Error code | Meaning                                                                            |
 | ---------- | ---------------------------------------------------------------------------------- |
 | 1101       | Worker threw a JavaScript exception.                                               |
-| 1102       | Worker exceeded CPU time limit. See: [Resource Limits](/about/limits)              |
+| 1102       | Worker exceeded CPU time limit. See: [Resource Limits](/reference/platform/limits)              |
 | 1015       | Your client IP is being rate limited.                                              |
-| 1027       | Worker exceeded free tier [daily request limit](/about/limits#Daily-Request-Limit) |
+| 1027       | Worker exceeded free tier [daily request limit](/reference/platform/limits#daily-request) |
 
 Other 11xx errors generally indicate a problem with the Workers runtime itself — please check our [status page](https://www.cloudflarestatus.com/) if you see one.
 

--- a/src/content/learning/fetch-event-lifecycle.md
+++ b/src/content/learning/fetch-event-lifecycle.md
@@ -1,8 +1,8 @@
 # FetchEvent Lifecycle
 
-When working with the [`fetch` event](/reference/apis/fetch-event) inside the Workers runtime, it helps to have a good idea of its lifecycle.
+When working with the [`fetch` event](/reference/runtime-apis/fetch-event) inside the Workers runtime, it helps to have a good idea of its lifecycle.
 
-The [FetchEvent](/reference/apis/fetch-event) lifecycle starts when Cloudflare's edge network receives a request whose URL is mapped to a Worker function, either by running on workers.dev, or being mapped to a [route](/reference/platform/routes); this causes the Workers runtime to trigger a `fetch` event and creates a FetchEvent Object to pass to the first event handler in the Workers function registered for `fetch`.
+The [FetchEvent](/reference/runtime-apis/fetch-event) lifecycle starts when Cloudflare's edge network receives a request whose URL is mapped to a Worker function, either by running on workers.dev, or being mapped to a [route](/reference/platform/routes); this causes the Workers runtime to trigger a `fetch` event and creates a FetchEvent Object to pass to the first event handler in the Workers function registered for `fetch`.
 
 The event handler can use any of the following to control what happens next:
 

--- a/src/content/learning/how-the-cache-works.md
+++ b/src/content/learning/how-the-cache-works.md
@@ -19,11 +19,11 @@ Since Cloudflare's Workers can run before, and after the cache, a Worker can als
 
 Conceptually, there are two ways to interact with Cloudflare's Cache using a Worker:
 
-- Call to [`fetch()`](/reference/apis/fetch) in a Workers script. Requests proxied through Cloudflare are cached even without Workers according to a zone's default or configured behavior (e.g. static assets like files ending in .jpg are cached by default). Workers can further customize this behavior by:
+- Call to [`fetch()`](/reference/runtime-apis/fetch) in a Workers script. Requests proxied through Cloudflare are cached even without Workers according to a zone's default or configured behavior (e.g. static assets like files ending in .jpg are cached by default). Workers can further customize this behavior by:
 
-  - Setting Cloudflare cache rules (i.e. operating on the `cf` object of a [request](/reference/apis/request/)).
+  - Setting Cloudflare cache rules (i.e. operating on the `cf` object of a [request](/reference/runtime-apis/request)).
 
-- Store responses using the [Cache API](/reference/apis/cache) from a Workers script. This allows caching responses that did not come from an origin and also provides finer control by:
+- Store responses using the [Cache API](/reference/runtime-apis/cache) from a Workers script. This allows caching responses that did not come from an origin and also provides finer control by:
 
   - Customizing cache behavior of any asset by setting headers such as `Cache-Control` on the response passed to `cache.put()`
 
@@ -43,13 +43,13 @@ For requests where Workers are behaving as middleware (i.e. they are sending a s
 
 ### `fetch`
 
-In the context of Workers a [`fetch`](/reference/apis/fetch) provided by the runtime communicates with the Cloudflare cache. First, `fetch` checks to see if the URL matches a different zone. If it does, it reads through that zone's cache (or Worker!). Otherwise, it reads through its own zone's cache, even if the URL is for a non-Cloudflare site. Cache settings on `fetch` automatically apply caching rules based on your Cloudflare settings. `fetch` does not allow you to _modify or inspect objects_ before they reach the cache, but does allow you to modify _how it will cache_.
+In the context of Workers a [`fetch`](/reference/runtime-apis/fetch) provided by the runtime communicates with the Cloudflare cache. First, `fetch` checks to see if the URL matches a different zone. If it does, it reads through that zone's cache (or Worker!). Otherwise, it reads through its own zone's cache, even if the URL is for a non-Cloudflare site. Cache settings on `fetch` automatically apply caching rules based on your Cloudflare settings. `fetch` does not allow you to _modify or inspect objects_ before they reach the cache, but does allow you to modify _how it will cache_.
 
 When a response fills the cache, the response header contains `CF-Cache-Status: HIT`. You can tell an object is attempting to cache if one sees the `CF-Cache-Status` at all.
 
-This [template](/templates/pages/cache_ttl) shows ways to customize Cloudflare cache behavior on a given request using fetch.
+This [template](/examples/pages/cache_ttl) shows ways to customize Cloudflare cache behavior on a given request using fetch.
 
-### [Cache API](/reference/apis/cache)
+### [Cache API](/reference/runtime-apis/cache)
 
 The Cache API can be thought of as an ephemeral key-value store, whereby the `Request` object (or more specifically, the request URL) is the key, and the `Response` is the value.
 
@@ -63,4 +63,4 @@ When to use the Cache API:
 - When you need to read from cache without calling fetch. (i.e. send me the response from `slow.com/resource` if and only if it’s already a HIT on cache using `caches.default.match(..)`.
 - Explicitly store a response in the cache using `caches.default.put(..)` and explicitly delete `caches.default.delete(..)`. For example, say your origin is returning `max-age:0` and you can't figure out how to change that header at your origin. You can explicitly tell Cloudflare to cache this response by setting `cache-control: max-age=1000` on the response passed into `cache.put()`.
 
-This [template](/templates/pages/cache_api) shows ways to use the cache API. For limits of the cache API see [limits](/about/limits#cache-api).
+This [template](/examples/pages/cache_api) shows ways to use the cache API. For limits of the cache API see [limits](/reference/platform/limits#cache-api-limits).

--- a/src/content/learning/how-workers-works.md
+++ b/src/content/learning/how-workers-works.md
@@ -2,7 +2,7 @@ import NetworkMap from "../../components/network-map"
 
 # How Workers works
 
-Though Cloudflare Workers behave similar to JavaScript in the browser or in Node.js, there are a few subtle differences in how you have to think about your code. Under the hood, the Workers runtime uses the [V8 engine](https://v8.dev/)—the same engine used by Chromium and Node.js. The Workers runtime also implements many of the standard [APIs](/reference/runtime/apis) available in most modern browsers.
+Though Cloudflare Workers behave similar to JavaScript in the browser or in Node.js, there are a few subtle differences in how you have to think about your code. Under the hood, the Workers runtime uses the [V8 engine](https://v8.dev/)—the same engine used by Chromium and Node.js. The Workers runtime also implements many of the standard [APIs](/reference/runtime-apis/web-standards) available in most modern browsers.
 
 The differences between JavaScript written for the browser or Node.js happen at runtime. Rather than running on an individual's machine (e.g a browser application or on a centralized server), Workers functions run on [Cloudflare's Edge Network](https://www.cloudflare.com/network/)—a growing global network of thousands of machines distributed across hundreds of locations.
 

--- a/src/content/learning/using-streams.md
+++ b/src/content/learning/using-streams.md
@@ -2,7 +2,7 @@
 
 The [Streams API](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) is a web standard API that allows JavaScript to programmatically access and process streams of data.
 
-Workers scripts don’t need to prepare an entire response body before delivering it to `event.respondWith()`. You can use [`TransformStream`](/reference/streams/transformstream) to stream a response body _after_ sending the front matter (that is, HTTP status line and headers). This allows you to minimize:
+Workers scripts don’t need to prepare an entire response body before delivering it to `event.respondWith()`. You can use [`TransformStream`](/reference/runtime-apis/streams/transformstream) to stream a response body _after_ sending the front matter (that is, HTTP status line and headers). This allows you to minimize:
 
 - The visitor’s time-to-first-byte.
 - The buffering done in the Workers script.
@@ -15,7 +15,7 @@ __Note:__ By default, the Cloudflare Workers service streams. Only use these API
 
 </Aside>
 
-The two primitives developers use to perform active streaming are [`TransformStream`](/reference/streams/transformstream) and the [`ReadableStream.pipeTo()`](/reference/streams/readablestream#pipetodestination-typepromisetype) method.
+The two primitives developers use to perform active streaming are [`TransformStream`](/reference/runtime-apis/streams/transformstream) and the [`ReadableStream.pipeTo()`](/reference/runtime-apis/streams/readablestream#methods) method.
 
 A basic pass-through usage of streams looks like this:
 
@@ -59,6 +59,6 @@ The Streams API is only available inside of the Request context, i.e. inside the
 
 ## See also
 
-- [Streams API Reference](/reference/streams/)
+- [Streams API Reference](/reference/runtime-apis/streams)
 - [MDN's Streams API documentation.](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API)
 - [Streams API Specification](https://streams.spec.whatwg.org/)

--- a/src/content/learning/workers-metrics.md
+++ b/src/content/learning/workers-metrics.md
@@ -23,7 +23,7 @@ Note: request traffic data may display a "drop off" near the last few minutes di
 
 ### Invocation statuses
 
-Worker invocation statuses indicate whether a Worker script executed successfully or failed to generate a response in the Workers runtime. Invocation statuses differ from HTTP status codes. In some cases, a Worker script invocation succeeds but does not generate a successful HTTP status because of another error encountered outside of the Workers runtime. Some invocation statuses result in a [Workers error code](/about/tips/debugging/#error-pages-generated-by-workers) being returned to the client.
+Worker invocation statuses indicate whether a Worker script executed successfully or failed to generate a response in the Workers runtime. Invocation statuses differ from HTTP status codes. In some cases, a Worker script invocation succeeds but does not generate a successful HTTP status because of another error encountered outside of the Workers runtime. Some invocation statuses result in a [Workers error code](/learning/debugging-workers#error-pages-generated-by-workers) being returned to the client.
 
 | Invocation status      | Definition                                                               | Workers Error code | GraphQL field          |
 | ---------------------- | ------------------------------------------------------------------------ | ------------------ | ---------------------- |
@@ -37,11 +37,11 @@ _¹ The Exceeded Resources status may appear when the Worker exceeds a [runtime 
 
 _² The Internal Error status may appear when the Workers runtime fails to process a request due to an internal failure in our system. These errors are not caused by any issue with the Worker code nor any resource limit. While requests with Internal Error status are rare, we expect that some may appear during normal operation. These requests are not counted towards usage for billing purposes. If you notice an elevated rate of requests with Internal Error status, please check www.cloudflarestatus.com._
 
-To further investagate exceptions, you can use [wrangler tail](/reference/cli/commands/#tail)
+To further investagate exceptions, you can use [wrangler tail](/reference/wrangler-cli/commands#tail)
 
 ### CPU Time
 
-The CPU time chart shows historical CPU time data broken down into relevant quantiles using [reservoir sampling](https://en.wikipedia.org/wiki/Reservoir_sampling). You can learn more about interpreting quantiles [here](https://www.statisticshowto.com/quantile-definition-find-easy-steps/). In some cases, higher quantiles may appear to exceed [CPU time limits](/reference/platform/limits/#cpu-execution-time-limit) without generating invocation errors because of a mechanism in the Workers runtime that allows rollover CPU time for requests below the CPU limit.
+The CPU time chart shows historical CPU time data broken down into relevant quantiles using [reservoir sampling](https://en.wikipedia.org/wiki/Reservoir_sampling). You can learn more about interpreting quantiles [here](https://www.statisticshowto.com/quantile-definition-find-easy-steps/). In some cases, higher quantiles may appear to exceed [CPU time limits](/reference/platform/limits#cpu-runtime) without generating invocation errors because of a mechanism in the Workers runtime that allows rollover CPU time for requests below the CPU limit.
 
 ### Metrics retention
 
@@ -51,7 +51,7 @@ Worker script metrics can be inspected for up to 3 months in the past in maximum
 
 ## Zone Analytics
 
-Aggregates request data for all scripts assigned to any [routes](/about/routes/) defined for a zone. You’ll find Zone Metrics on the [analytics tab](https://dash.cloudflare.com/?zone=analytics/workers) of your Cloudflare dashboard.
+Aggregates request data for all scripts assigned to any [routes](/reference/platform/routes) defined for a zone. You’ll find Zone Metrics on the [analytics tab](https://dash.cloudflare.com/?zone=analytics/workers) of your Cloudflare dashboard.
 
 Zone data can be scoped by time range within the last 30 days. The dashboard includes charts and information described below.
 

--- a/src/content/reference/platform/limits.md
+++ b/src/content/reference/platform/limits.md
@@ -61,7 +61,7 @@ Accounts using the Workers free plan are subject to a burst rate limit of 1000 r
 
 ### Daily request
 
-Accounts using the Workers free plan are subject to a daily request limit of 100,000 requests. Free plan daily requests counts reset at midnight UTC. A Worker that fails as a result of daily request limit errors can be configured by toggling its corresponding [route](/about/routes/) in two modes: _Fail open_ and _Fail closed_.
+Accounts using the Workers free plan are subject to a daily request limit of 100,000 requests. Free plan daily requests counts reset at midnight UTC. A Worker that fails as a result of daily request limit errors can be configured by toggling its corresponding [route](/reference/platform/routes) in two modes: _Fail open_ and _Fail closed_.
 
 #### Fail open
 
@@ -75,9 +75,9 @@ Routes in fail closed mode will display a Cloudflare 1027 error page to visitors
 
 ## Memory
 
-Only one Workers instance runs on each of the many global Cloudflare edge servers. Each Workers instance can consume up to 128MB of memory. Use [global variables](/reference/apis/standard/) to persist data between requests on individual nodes; note however, that nodes are occasionally evicted from memory.
+Only one Workers instance runs on each of the many global Cloudflare edge servers. Each Workers instance can consume up to 128MB of memory. Use [global variables](/reference/runtime-apis/web-standards) to persist data between requests on individual nodes; note however, that nodes are occasionally evicted from memory.
 
-Use the [TransformStream API](/reference/apis/streams/) to stream responses if you are concerned about memory usage. This avoids loading an entire response into memory.
+Use the [TransformStream API](/reference/runtime-apis/streams/transformstream) to stream responses if you are concerned about memory usage. This avoids loading an entire response into memory.
 
 --------------------------------
 
@@ -85,7 +85,7 @@ Use the [TransformStream API](/reference/apis/streams/) to stream responses if y
 
 Most Workers requests consume less than a millisecond. It’s rare to find a normally operating Workers script that exceeds the CPU time limit. A Worker may consume up to 10ms on the free plan and 50ms on the Unlimited tier. The 10ms allowance on the free plan is enough execution time for most use cases including application hosting.
 
-There is no limit on the real runtime for a Workers script. As long as the client that sent the request remains connected, the Workers script can continue processing, making subrequests, and setting timeouts on behalf of that request. When the client disconnects, all tasks associated with that client request are canceled. You can use [`event.waitUntil()`](/reference/apis/fetch-event/) to delay cancellation for another 30 seconds or until the promise passed to `waitUntil()` completes.
+There is no limit on the real runtime for a Workers script. As long as the client that sent the request remains connected, the Workers script can continue processing, making subrequests, and setting timeouts on behalf of that request. When the client disconnects, all tasks associated with that client request are canceled. You can use [`event.waitUntil()`](/reference/runtime-apis/fetch-event) to delay cancellation for another 30 seconds or until the promise passed to `waitUntil()` completes.
 
 --------------------------------
 
@@ -93,7 +93,7 @@ There is no limit on the real runtime for a Workers script. As long as the clien
 
 ### Can a Workers script make subrequests to load other sites on the Internet?
 
-Yes. Use the [Fetch API](/reference/apis/fetch/) to make arbitrary requests to other Internet resources.
+Yes. Use the [Fetch API](/reference/runtime-apis/fetch) to make arbitrary requests to other Internet resources.
 
 ### How many subrequests can I make?
 
@@ -103,7 +103,7 @@ The limit for subrequests a Workers script can make is 50 per request. Each subr
 
 There is no hard limit on the amount of real time a Worker may use. As long as the client which sent a request remains connected, the Worker may continue processing, making subrequests, and setting timeouts on behalf of that request.
 
-When the client disconnects, all tasks associated with that client’s request are proactively canceled. If the Worker passed a promise to [`event.waitUntil()`](/reference/apis/fetch-event), cancellation will be delayed until the promise has completed or until an additional 30 seconds have elapsed, whichever happens first.
+When the client disconnects, all tasks associated with that client’s request are proactively canceled. If the Worker passed a promise to [`event.waitUntil()`](/reference/runtime-apis/fetch-event), cancellation will be delayed until the promise has completed or until an additional 30 seconds have elapsed, whichever happens first.
 
 --------------------------------
 
@@ -111,9 +111,9 @@ When the client disconnects, all tasks associated with that client’s request a
 
 While handling a request, each Worker script is allowed to have up to six connections open simultaneously. The connections opened by the following API calls all count toward this limit:
 
-- the `fetch()` method of the [Fetch API](/reference/apis/fetch/)
-- `get()`, `put()`, `list()`, and `delete()` methods of [Workers KV namespace objects](/reference/apis/kv)
-- `put()`, `match()`, and `delete()` methods of [Cache objects](/reference/apis/cache/)
+- the `fetch()` method of the [Fetch API](/reference/runtime-apis/fetch)
+- `get()`, `put()`, `list()`, and `delete()` methods of [Workers KV namespace objects](/reference/runtime-apis/kv)
+- `put()`, `match()`, and `delete()` methods of [Cache objects](/reference/runtime-apis/cache)
 
 Once a Worker has six connections open, it can still attempt to open additional connections. However, these attempts are put in a pending queue - the connections won't be actually be initiated until one of the currently open connections has closed. Since earlier connections can delay later ones, if a Worker tries to make many simultaneous subrequests, its later subrequests may appear to take longer to start.
 
@@ -130,6 +130,7 @@ Each environment variable has a size limitation of 5 KiB.
 
 ### Script size
 
+<!-- TODO(soon): Broken link to Bindings API documentation. -->
 A Workers script plus any [Asset Bindings](/tooling/api/bindings) can be up to 1MB in size after compression.
 
 ### Number of scripts

--- a/src/content/reference/platform/routes.md
+++ b/src/content/reference/platform/routes.md
@@ -19,7 +19,7 @@ Cloudflare Site routes are comprised of:
 
 - Route URL (see [Matching Behavior](#matching-behavior))
 - Worker script to execute on matching requests
-- Failure mode for rate-limited accounts on the free plan (see [Daily Request Limits](/about/limits#request-limits))
+- Failure mode for rate-limited accounts on the free plan (see [Daily Request Limits](/reference/platform/limits#request-limits))
 
 The Routes REST API documentation can be found [here](https://api.cloudflare.com/#worker-routes-properties)
 

--- a/src/content/reference/platform/scripts.md
+++ b/src/content/reference/platform/scripts.md
@@ -108,7 +108,7 @@ The `namespace_id` value should correspond to the identifier associated with the
 
 #### Add a Wasm Module
 
-If your Worker uses a [Wasm Module](/templates/boilerplates/rustwasm/), you will want to add a `wasm_module` binding object to the `"bindings"` array in metadata.json:
+If your Worker uses a [Wasm Module](/examples/boilerplates/rustwasm/), you will want to add a `wasm_module` binding object to the `"bindings"` array in metadata.json:
 
 ```json
 {
@@ -206,7 +206,7 @@ A multipart form containing a valid JavaScript file, a `metadata.json` file spec
 
 - `success`: Boolean
 - `result`: A [Script Object](#object-specification) of the resulting script. Empty if success is false
-- `errors`: An array of [Error Objects](/tooling/api/requests#error-object). Empty if success is true
+- `errors`: An array of [Error Objects](#errors). Empty if success is true
 - `messages`: An array of strings (unused)
 
 ##### Errors
@@ -221,7 +221,7 @@ error: {
 }
 ```
 
-###### Exceeded [Script Limit](/about/limits)
+###### Exceeded [Script Limit](/reference/platform/limits)
 
 ```json
 status: 403
@@ -334,7 +334,7 @@ curl -X GET "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/worker
 
 - `success`: Boolean
 - `result`: An array of [Script Objects](#object-specification). Empty if success is false; does not include raw script text.
-- `errors`: An array of [Error Objects](/tooling/api/requests#error-object). Empty if success is true
+- `errors`: An array of [Error Objects](#errors-1). Empty if success is true
 - `messages`: An array of strings (unused)
 
 ##### Errors
@@ -498,7 +498,7 @@ curl -X DELETE "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/wor
 
 - `success`: Boolean
 - `result`: An object containing the id (etag) of the deleted script
-- `errors`: An array of [Error Objects](/tooling/api/requests#error-object). Empty if success is true
+- `errors`: An array of [Error Objects](#errors-3). Empty if success is true
 - `messages`: An array of strings (unused)
 
 ##### Errors

--- a/src/content/reference/runtime-apis/cache.md
+++ b/src/content/reference/runtime-apis/cache.md
@@ -10,7 +10,7 @@ The Service Workers Cache API is currently unimplemented in the Cloudflare Worke
 
 <Aside>
 
-__Note__: This individualized zone cache object differs from Cloudflare’s Global CDN, for details see: [Using the Cache](/about/using-cache).
+__Note__: This individualized zone cache object differs from Cloudflare’s Global CDN, for details see: [How the Cache Works](/learning/how-the-cache-works).
 
 </Aside>
 
@@ -77,11 +77,11 @@ cache.put(request, response)
 
 <Definitions>
 
-- `request` <Type>string</Type>|<TypeLink href="/reference/request">Request</TypeLink>
-    - Either a string or a [`Request`](/reference/request) object to serve as the key. If a string is passed, it is interpreted as the URL for a new Request object.
+- `request` <Type>string</Type>|<TypeLink href="/reference/runtime-apis/request">Request</TypeLink>
+    - Either a string or a [`Request`](/reference/runtime-apis/request) object to serve as the key. If a string is passed, it is interpreted as the URL for a new Request object.
 
-- `response` <TypeLink href="/reference/request">Request</TypeLink>
-    -  A [`Response`](/reference/response) object to store under the given key.
+- `response` <TypeLink href="/reference/runtime-apis/request">Request</TypeLink>
+    -  A [`Response`](/reference/runtime-apis/response) object to store under the given key.
 
 </Definitions>
 
@@ -100,7 +100,7 @@ cache.match(request, options)
 
 <Definitions>
 
-- <Code>match(request, options)</Code> <TypeLink href="/reference/response">Promise{`<Response>`}</TypeLink>
+- <Code>match(request, options)</Code> <TypeLink href="/reference/runtime-apis/response">Promise{`<Response>`}</TypeLink>
 
     - Returns a promise wrapping the response object keyed to that request.
 
@@ -110,9 +110,9 @@ cache.match(request, options)
 
 <Definitions>
 
-- `request` <Type>string</Type>|<TypeLink href="/reference/request">Request</TypeLink>
+- `request` <Type>string</Type>|<TypeLink href="/reference/runtime-apis/request">Request</TypeLink>
 
-    - The string or [`Request`](/reference/apis/request) object used as the lookup key. Strings are interpreted as the URL for a new `Request` object.
+    - The string or [`Request`](/reference/runtime-apis/request) object used as the lookup key. Strings are interpreted as the URL for a new `Request` object.
 
 - `options`
     -  Can contain one possible property: `ignoreMethod` (Boolean) Consider the request method a GET regardless of its actual value.
@@ -147,7 +147,7 @@ cache.delete(request, options)
 
 <Definitions>
 
-- <Code>delete(request, options)</Code> <TypeLink href="/reference/response">Promise{`<boolean>`}</TypeLink>
+- <Code>delete(request, options)</Code> <TypeLink href="/reference/runtime-apis/response">Promise{`<boolean>`}</TypeLink>
 
 </Definitions>
 
@@ -160,9 +160,9 @@ Deletes the `Response` object from the cache and returns a `Promise` for a Boole
 
 <Definitions>
 
-- `request` <Type>string</Type>|<TypeLink href="/reference/request">Request</TypeLink>
+- `request` <Type>string</Type>|<TypeLink href="/reference/runtime-apis/request">Request</TypeLink>
 
-    - The string or [`Request`](/reference/apis/request) object used as the lookup key. Strings are interpreted as the URL for a new `Request` object.
+    - The string or [`Request`](/reference/runtime-apis/request) object used as the lookup key. Strings are interpreted as the URL for a new `Request` object.
 
 <!-- What type is this? -->
 - `options`

--- a/src/content/reference/runtime-apis/fetch-event.md
+++ b/src/content/reference/runtime-apis/fetch-event.md
@@ -2,6 +2,7 @@
 
 ## Background
 
+<!-- TODO(soon): The linked addEventListener reference does not exist in the new docs. -->
 The event type for HTTP requests dispatched to a Worker (i.e the `Object` passed through as `event` in [`addEventListener()`](/reference/apis/addEventListener).
 
 ## Constructor
@@ -19,7 +20,7 @@ addEventListener('fetch', (event) => {
 - `event.type` <Type>string</Type>
     - The type of event.
 
-- `event.request` <TypeLink href="/reference/request">Request</TypeLink>
+- `event.request` <TypeLink href="/reference/runtime-apis/request">Request</TypeLink>
     - The incoming HTTP request triggering `FetchEvent`.
 
 </Definitions>
@@ -30,7 +31,7 @@ When a Workers script receives a request, the Workers runtime triggers a FetchEv
 
 <Definitions>
 
--  <Code>event.respondWith(response<TypeLink href="/reference/request">Request</TypeLink>|<ParamType>Promise</ParamType>)</Code> <Type>void</Type>
+-  <Code>event.respondWith(response<TypeLink href="/reference/runtime-apis/request">Request</TypeLink>|<ParamType>Promise</ParamType>)</Code> <Type>void</Type>
 
     - Intercept the request and send a custom response. _If no event handler calls `respondWith()` the runtime attempts to request the origin as if no Worker script exists. If no origin is setup (e.g. workers.dev sites), then the Workers script must call `respondWith()` for a valid response._
 

--- a/src/content/reference/runtime-apis/fetch.md
+++ b/src/content/reference/runtime-apis/fetch.md
@@ -58,12 +58,6 @@ async function eventHandler(event) {
 
 --------------------------------
 
-## Common issues
-
-Sometimes you’ll find that when you create instances of `Class`, unexpected things happen. It’s important to remember that you can always [debug your `Class`](#learning-page-about-debugging).
-
---------------------------------
-
 ## See also
 
 - [`Fetch HTML`](/examples)

--- a/src/content/reference/runtime-apis/fetch.md
+++ b/src/content/reference/runtime-apis/fetch.md
@@ -8,7 +8,8 @@ The `fetch` method is implemented on the ServiceWorkerGlobalScope. See [MDN docu
 
 <Aside>
 
-__Note:__ Asynchronous tasks such as `fetch` are not executed at the top level in a Worker script and must be executed within a FetchEvent handler such as [`respondWith`](/reference/fetch-event#methods). Learn more about [Request Contexts](/about/tips/request-context).
+<!-- TODO(soon): Broken link. -->
+__Note:__ Asynchronous tasks such as `fetch` are not executed at the top level in a Worker script and must be executed within a FetchEvent handler such as [`respondWith`](/reference/runtime-apis/fetch-event#methods). Learn more about [Request Contexts](/about/tips/request-context).
 
 </Aside>
 
@@ -35,7 +36,7 @@ async function eventHandler(event) {
 <!-- Where do we have the return type in this format? -->
 <Definitions>
 
-- <Code>fetch()</Code> <TypeLink href="/reference/apis/response">Promise{`<Response>`}</TypeLink>
+- <Code>fetch()</Code> <TypeLink href="/reference/runtime-apis/response">Promise{`<Response>`}</TypeLink>
 
   - Fetch returns a promise to a Response.
 
@@ -47,10 +48,10 @@ async function eventHandler(event) {
 
 <Definitions>
 
-- `request` <TypeLink href="/reference/apis/request">Request</TypeLink> | <Type>string</Type>
-  - The <TypeLink href="/reference/apis/request">Request</TypeLink> object or a string represents the URL to fetch.
+- `request` <TypeLink href="/reference/runtime-apis/request">Request</TypeLink> | <Type>string</Type>
+  - The <TypeLink href="/reference/runtime-apis/request">Request</TypeLink> object or a string represents the URL to fetch.
 
-- `init` <TypeLink href="/reference/apis/request#requestinit">RequestInit</TypeLink>
+- `init` <TypeLink href="/reference/runtime-apis/request#requestinit">RequestInit</TypeLink>
   - The content of the request.
 
 </Definitions>

--- a/src/content/reference/runtime-apis/kv.md
+++ b/src/content/reference/runtime-apis/kv.md
@@ -30,7 +30,8 @@ await NAMESPACE.put(key, value)
 
 This method returns a `Promise` that you should `await` on in order to verify a successful update.
 
-You can also [write key-value pairs from the command line with Wrangler](/reference/wrangler-cli/kv_commands/#kv-key).
+You can also [write key-value pairs from the command line with
+Wrangler](/reference/wrangler-cli/commands#kvkey).
 
 Finally, you can [write data via the API](https://api.cloudflare.com/#workers-kv-namespace-write-key-value-pair).
 
@@ -38,7 +39,10 @@ Due to the eventually consistent nature of Workers KV, it's a common pattern to 
 
 #### Writing data in bulk
 
-You can [write more than one key-value pair at a time with wrangler](/reference/wrangler-cli/kv_commands/#kv-bulk) or [via the API](https://api.cloudflare.com/#workers-kv-namespace-write-multiple-key-value-pairs), up to 10,000 KV pairs. A `key` and `value` are required for each KV pair. The entire request size must be less than 100 megabytes. We do not support this from within a Worker script at this time.
+You can [write more than one key-value pair at a time with
+wrangler](/reference/wrangler-cli/commands#kvbulk) or [via the
+API](https://api.cloudflare.com/#workers-kv-namespace-write-multiple-key-value-pairs), up to 10,000 KV pairs. A `key` and `value` are required for each KV pair. The entire request size must be less than 100 megabytes.
+We do not support this from within a Worker script at this time.
 
 #### Expiring keys
 
@@ -70,7 +74,9 @@ We talked about the basic form of the `put` method above, but this call also has
 
 These assume that `secondsSinceEpoch` and `secondsFromNow` are variables defined elsewhere in your Worker code.
 
-You can also [write with an expiration on the command line via Wrangler](/reference/wrangler-cli/kv_commands/#kv-key) or [via the API](https://api.cloudflare.com/#workers-kv-namespace-write-key-value-pair).
+You can also [write with an expiration on the command line via
+Wrangler](/reference/wrangler-cli/commands#kvkey) or [via the
+API](https://api.cloudflare.com/#workers-kv-namespace-write-key-value-pair).
 
 #### Metadata
 
@@ -107,7 +113,8 @@ async function handleRequest(request) {
 }
 ```
 
-You can also [read key-value pairs from the command line with wrangler](/reference/wrangler-cli/kv_commands/#kv-key).
+You can also [read key-value pairs from the command line with
+wrangler](/reference/wrangler-cli/commands#kvkey).
 
 Finally, you can also [read from the API](https://api.cloudflare.com/#workers-kv-namespace-read-key-value-pair).
 
@@ -164,7 +171,7 @@ async function handleRequest(request) {
 }
 ```
 
-You can also [list keys on the command line with Wrangler](/reference/wrangler-cli/kv_commands/#kv-key) or [via the API](https://api.cloudflare.com/#workers-kv-namespace-list-a-namespace-s-keys).
+You can also [list keys on the command line with Wrangler](/reference/wrangler-cli/commands#kvkey) or [via the API](https://api.cloudflare.com/#workers-kv-namespace-list-a-namespace-s-keys).
 
 Changes may take up to 60 seconds to be visible when listing keys.
 

--- a/src/content/reference/runtime-apis/kv.md
+++ b/src/content/reference/runtime-apis/kv.md
@@ -30,7 +30,7 @@ await NAMESPACE.put(key, value)
 
 This method returns a `Promise` that you should `await` on in order to verify a successful update.
 
-You can also [write key-value pairs from the command line with Wrangler](/tooling/wrangler/kv_commands/#kv-key).
+You can also [write key-value pairs from the command line with Wrangler](/reference/wrangler-cli/kv_commands/#kv-key).
 
 Finally, you can [write data via the API](https://api.cloudflare.com/#workers-kv-namespace-write-key-value-pair).
 
@@ -38,7 +38,7 @@ Due to the eventually consistent nature of Workers KV, it's a common pattern to 
 
 #### Writing data in bulk
 
-You can [write more than one key-value pair at a time with wrangler](/tooling/wrangler/kv_commands/#kv-bulk) or [via the API](https://api.cloudflare.com/#workers-kv-namespace-write-multiple-key-value-pairs), up to 10,000 KV pairs. A `key` and `value` are required for each KV pair. The entire request size must be less than 100 megabytes. We do not support this from within a Worker script at this time.
+You can [write more than one key-value pair at a time with wrangler](/reference/wrangler-cli/kv_commands/#kv-bulk) or [via the API](https://api.cloudflare.com/#workers-kv-namespace-write-multiple-key-value-pairs), up to 10,000 KV pairs. A `key` and `value` are required for each KV pair. The entire request size must be less than 100 megabytes. We do not support this from within a Worker script at this time.
 
 #### Expiring keys
 
@@ -70,7 +70,7 @@ We talked about the basic form of the `put` method above, but this call also has
 
 These assume that `secondsSinceEpoch` and `secondsFromNow` are variables defined elsewhere in your Worker code.
 
-You can also [write with an expiration on the command line via Wrangler](/tooling/wrangler/kv_commands/#kv-key) or [via the API](https://api.cloudflare.com/#workers-kv-namespace-write-key-value-pair).
+You can also [write with an expiration on the command line via Wrangler](/reference/wrangler-cli/kv_commands/#kv-key) or [via the API](https://api.cloudflare.com/#workers-kv-namespace-write-key-value-pair).
 
 #### Metadata
 
@@ -107,7 +107,7 @@ async function handleRequest(request) {
 }
 ```
 
-You can also [read key-value pairs from the command line with wrangler](/tooling/wrangler/kv_commands/#kv-key).
+You can also [read key-value pairs from the command line with wrangler](/reference/wrangler-cli/kv_commands/#kv-key).
 
 Finally, you can also [read from the API](https://api.cloudflare.com/#workers-kv-namespace-read-key-value-pair).
 
@@ -146,7 +146,7 @@ This will remove the key and value from your namespace. As with any operations, 
 
 This method returns a promise that you should `await` on in order to verify successful deletion.
 
-You can also [delete key-value pairs from the command line with Wrangler](/tooling/wrangler/kv_commands/#kv-key) or [via the API](https://api.cloudflare.com/#workers-kv-namespace-delete-key-value-pair).
+You can also [delete key-value pairs from the command line with Wrangler](/reference/wrangler-cli/kv_commands/#kv-key) or [via the API](https://api.cloudflare.com/#workers-kv-namespace-delete-key-value-pair).
 
 ### Listing keys
 
@@ -164,7 +164,7 @@ async function handleRequest(request) {
 }
 ```
 
-You can also [list keys on the command line with Wrangler](/tooling/wrangler/kv_commands/#kv-key) or [via the API](https://api.cloudflare.com/#workers-kv-namespace-list-a-namespace-s-keys).
+You can also [list keys on the command line with Wrangler](/reference/wrangler-cli/kv_commands/#kv-key) or [via the API](https://api.cloudflare.com/#workers-kv-namespace-list-a-namespace-s-keys).
 
 Changes may take up to 60 seconds to be visible when listing keys.
 

--- a/src/content/reference/runtime-apis/request.md
+++ b/src/content/reference/runtime-apis/request.md
@@ -39,7 +39,8 @@ The global `fetch` method itself invokes the `Request` constructor, thus the [`R
 
 <Aside header="Learn more">
 
-Read [Understanding the FetchEvent Lifecycle](../learning/understanding-the-fetch-event-lifecycle) and [Understanding the Request Context](../learning/understanding-the-request-context) for a deeper understanding of these fundamental Workers concepts.
+<!-- TODO(soon): /learning/understanding-the-request-context does not exist. -->
+Read [Understanding the FetchEvent Lifecycle](/learning/fetch-event-lifecycle) and [Understanding the Request Context](/learning/understanding-the-request-context) for a deeper understanding of these fundamental Workers concepts.
 
 </Aside>
 
@@ -183,7 +184,7 @@ All properties of an incoming `Request` object (i.e. `event.request`) are read o
 
 ### `IncomingRequestCfProperties`
 
-In addition to the properties on the standard [`Request`](/reference/apis/request) object, the `request.cf` object on an inbound `Request` contains information about the request provided by Cloudflare’s edge.
+In addition to the properties on the standard [`Request`](/reference/runtime-apis/request) object, the `request.cf` object on an inbound `Request` contains information about the request provided by Cloudflare’s edge.
 
 <Definitions>
 

--- a/src/content/reference/runtime-apis/response.md
+++ b/src/content/reference/runtime-apis/response.md
@@ -35,8 +35,8 @@ Valid options for the `options` object include:
   - `statusText` <Type>string</Type>
     - The status message associated with the status code, like, `OK`.
 
-  - `headers` <TypeLink href="/reference/apis/request#constructor-parameters">Headers</TypeLink> | <TypeLink href="https://developer.mozilla.org/en-US/docs/Web/API/ByteString">ByteString</TypeLink>
-    - Any headers to add to your response that are contained within a [`Headers`](/reference/apis/request#constructor-parameters) object or object literal of [`ByteString`](https://developer.mozilla.org/en-US/docs/Web/API/ByteString) key/value pairs.
+  - `headers` <TypeLink href="/reference/runtime-apis/request#constructor-parameters">Headers</TypeLink> | <TypeLink href="https://developer.mozilla.org/en-US/docs/Web/API/ByteString">ByteString</TypeLink>
+    - Any headers to add to your response that are contained within a [`Headers`](/reference/runtime-apis/request#constructor-parameters) object or object literal of [`ByteString`](https://developer.mozilla.org/en-US/docs/Web/API/ByteString) key/value pairs.
 
 </Definitions>
 
@@ -48,7 +48,7 @@ Valid options for the `options` object include:
   - A simple getter to get the body contents.
 - `bodyUsed` <Type>boolean</Type>
   - A boolean indicating if the body was used in the response.
-- `headers` <TypeLink href="/reference/apis/request#constructor-parameters">Headers</TypeLink>
+- `headers` <TypeLink href="/reference/runtime-apis/request#constructor-parameters">Headers</TypeLink>
   - The headers for the request.
 - `ok` <Type>boolean</Type>
   - A boolean indicating if the response was successful (status in the range 200-299).

--- a/src/content/reference/runtime-apis/response.md
+++ b/src/content/reference/runtime-apis/response.md
@@ -35,8 +35,8 @@ Valid options for the `options` object include:
   - `statusText` <Type>string</Type>
     - The status message associated with the status code, like, `OK`.
 
-  - `headers` <TypeLink href="/reference/runtime-apis/request#constructor-parameters">Headers</TypeLink> | <TypeLink href="https://developer.mozilla.org/en-US/docs/Web/API/ByteString">ByteString</TypeLink>
-    - Any headers to add to your response that are contained within a [`Headers`](/reference/runtime-apis/request#constructor-parameters) object or object literal of [`ByteString`](https://developer.mozilla.org/en-US/docs/Web/API/ByteString) key/value pairs.
+  - `headers` <TypeLink href="/reference/runtime-apis/request#parameters">Headers</TypeLink> | <TypeLink href="https://developer.mozilla.org/en-US/docs/Web/API/ByteString">ByteString</TypeLink>
+    - Any headers to add to your response that are contained within a [`Headers`](/reference/runtime-apis/request#parameters) object or object literal of [`ByteString`](https://developer.mozilla.org/en-US/docs/Web/API/ByteString) key/value pairs.
 
 </Definitions>
 
@@ -48,7 +48,7 @@ Valid options for the `options` object include:
   - A simple getter to get the body contents.
 - `bodyUsed` <Type>boolean</Type>
   - A boolean indicating if the body was used in the response.
-- `headers` <TypeLink href="/reference/runtime-apis/request#constructor-parameters">Headers</TypeLink>
+- `headers` <TypeLink href="/reference/runtime-apis/request#parameters">Headers</TypeLink>
   - The headers for the request.
 - `ok` <Type>boolean</Type>
   - A boolean indicating if the response was successful (status in the range 200-299).

--- a/src/content/reference/runtime-apis/streams/readablestream.md
+++ b/src/content/reference/runtime-apis/streams/readablestream.md
@@ -2,7 +2,7 @@
 
 ## Background
 
-A `ReadableStream` is returned by the `readable` property inside [`TransformStream`](/reference/streams/transformstream). On the Workers platform, `ReadableStream`
+A `ReadableStream` is returned by the `readable` property inside [`TransformStream`](/reference/runtime-apis/streams/transformstream). On the Workers platform, `ReadableStream`
 cannot be created directly using the `ReadableStream` constructor.
 
 ## Properties
@@ -22,9 +22,9 @@ cannot be created directly using the `ReadableStream` constructor.
 
   - Pipes the readable stream to a given writable stream `destination` and returns a promise that is fulfilled when the `write` operation succeeds or rejects it if the operation fails.
 
-- <Code>getReader(options<ParamType>Object</ParamType>)</Code> <TypeLink href="/reference/streams/readablestreamdefaultreader">ReadableStreamDefaultReader</TypeLink>
+- <Code>getReader(options<ParamType>Object</ParamType>)</Code> <TypeLink href="/reference/runtime-apis/streams/readablestreamdefaultreader">ReadableStreamDefaultReader</TypeLink>
 
-  - Gets an instance of `ReadableStreamDefaultReader` and locks the `ReadableStream` to that reader instance. This method accepts an object argument indicating _options_.  The only supported option is `mode`, which can be set to `byob` to create a [`ReadableStreamBYOBReader`](/reference/streams/readablestreambyobreader), as shown here:
+  - Gets an instance of `ReadableStreamDefaultReader` and locks the `ReadableStream` to that reader instance. This method accepts an object argument indicating _options_.  The only supported option is `mode`, which can be set to `byob` to create a [`ReadableStreamBYOBReader`](/reference/runtime-apis/streams/readablestreambyobreader), as shown here:
 
     ```js
     let reader = readable.getReader({ mode: 'byob' })

--- a/src/content/reference/runtime-apis/streams/readablestreambyobreader.md
+++ b/src/content/reference/runtime-apis/streams/readablestreambyobreader.md
@@ -11,9 +11,9 @@ title: ReadableStream BYOBReader
 
 `BYOB` is an abbreviation of "bring your own buffer." A `ReadableStreamBYOBReader` allows reading into a developer-supplied buffer, thus minimizing copies.
 
-An instance of `ReadableStreamBYOBReader` is functionally identical to [`ReadableStreamDefaultReader`](/reference/streams/readablestreamdefaultreader) with the exception of the `read` method.
+An instance of `ReadableStreamBYOBReader` is functionally identical to [`ReadableStreamDefaultReader`](/reference/runtime-apis/streams/readablestreamdefaultreader) with the exception of the `read` method.
 
-A `ReadableStreamBYOBReader` is not instantiated via its constructor. Rather, it is retrieved from a [`ReadableStream`](/reference/streams/readablestream):
+A `ReadableStreamBYOBReader` is not instantiated via its constructor. Rather, it is retrieved from a [`ReadableStream`](/reference/runtime-apis/streams/readablestream):
 
 ```js
 const { readable, writable } = new TransformStream()

--- a/src/content/reference/runtime-apis/streams/readablestreamdefaultreader.md
+++ b/src/content/reference/runtime-apis/streams/readablestreamdefaultreader.md
@@ -7,9 +7,9 @@ title: ReadableStream DefaultReader
 
 ## Background
 
-A reader is used when you want to read from a [ReadableStream](/reference/streams/readablestream), rather than piping its output to a [WritableStream](/reference/streams/writablestream).
+A reader is used when you want to read from a [ReadableStream](/reference/runtime-apis/streams/readablestream), rather than piping its output to a [WritableStream](/reference/runtime-apis/streams/writablestream).
 
-A `ReadableStreamDefaultReader` is not instantiated via its constructor. Rather, it is retrieved from a [`ReadableStream`](/reference/streams/readablestream):
+A `ReadableStreamDefaultReader` is not instantiated via its constructor. Rather, it is retrieved from a [`ReadableStream`](/reference/runtime-apis/streams/readablestream):
 
 ```js
 const { readable, writable } = new TransformStream()
@@ -36,7 +36,7 @@ const reader = readable.getReader()
 
 - <Code>cancel(reason<ParamType>string</ParamType><PropMeta>optional</PropMeta>)</Code> <Type>void</Type>
 
-  - Cancels the stream. `reason` is an optional human-readable string indicating the reason for cancellation. `reason` will be passed to the underlying source's cancel algorithm -- if this readable stream is one side of a [TransformStream](/reference/streams/transformstream), then its cancel algorithm causes the transform's writable side to become errored with `reason`.
+  - Cancels the stream. `reason` is an optional human-readable string indicating the reason for cancellation. `reason` will be passed to the underlying source's cancel algorithm -- if this readable stream is one side of a [TransformStream](/reference/runtime-apis/streams/transformstream), then its cancel algorithm causes the transform's writable side to become errored with `reason`.
 
     <Aside type="warning" header="Warning">
 

--- a/src/content/reference/runtime-apis/streams/writablestream.md
+++ b/src/content/reference/runtime-apis/streams/writablestream.md
@@ -2,9 +2,9 @@
 
 ## Background
 
-A `WritableStream` is the `writable` property of a [`TransformStream`](/reference/streams/transformstream). On the Workers platform, `WritableStream` can’t be directly created using the `WritableStream` constructor.
+A `WritableStream` is the `writable` property of a [`TransformStream`](/reference/runtime-apis/streams/transformstream). On the Workers platform, `WritableStream` can’t be directly created using the `WritableStream` constructor.
 
-A typical way to write to a `WritableStream` is to simply pipe a [`ReadableStream`](/reference/streams/readablestream) to it.
+A typical way to write to a `WritableStream` is to simply pipe a [`ReadableStream`](/reference/runtime-apis/streams/readablestream) to it.
 
 ```js
 readableStream.pipeTo(writableStream)
@@ -19,7 +19,7 @@ const writer = writableStream.getWriter()
 writer.write(data)
 ```
 
-See the [WritableStreamDefaultWriter](/reference/streams/writablestreamdefaultwriter) documentation for further detail.
+See the [WritableStreamDefaultWriter](/reference/runtime-apis/streams/writablestreamdefaultwriter) documentation for further detail.
 
 ## Properties
 
@@ -37,7 +37,7 @@ See the [WritableStreamDefaultWriter](/reference/streams/writablestreamdefaultwr
 
 - <Code>abort(reason<ParamType>string</ParamType><PropMeta>optional</PropMeta>)</Code> <Type>Promise&lt;void></Type>
 
-  - Aborts the stream. This method returns a promise that fulfills with a response `undefined`. `reason` is an optional human-readable string indicating the reason for cancellation. `reason` will be passed to the underlying sink's abort algorithm. If this writable stream is one side of a [TransformStream](/reference/streams/transformstream), then its abort algorithm causes the transform's readable side to become errored with `reason`.
+  - Aborts the stream. This method returns a promise that fulfills with a response `undefined`. `reason` is an optional human-readable string indicating the reason for cancellation. `reason` will be passed to the underlying sink's abort algorithm. If this writable stream is one side of a [TransformStream](/reference/runtime-apis/streams/transformstream), then its abort algorithm causes the transform's readable side to become errored with `reason`.
 
   <Aside type="warning" header="Warning">
 
@@ -45,7 +45,7 @@ See the [WritableStreamDefaultWriter](/reference/streams/writablestreamdefaultwr
 
   </Aside>
 
-- `getWriter()` <TypeLink href="/reference/streams/writablestreamdefaultwriter">WritableStreamDefaultWriter</TypeLink>
+- `getWriter()` <TypeLink href="/reference/runtime-apis/streams/writablestreamdefaultwriter">WritableStreamDefaultWriter</TypeLink>
 
   - Gets an instance of `WritableStreamDefaultWriter` and locks the `WritableStream` to that writer instance.
 

--- a/src/content/reference/runtime-apis/streams/writablestreamdefaultwriter.md
+++ b/src/content/reference/runtime-apis/streams/writablestreamdefaultwriter.md
@@ -7,7 +7,7 @@ title: WritableStream DefaultWriter
 
 ## Background
 
-A writer is used when you want to write directly to a [`WritableStream`](/reference/streams/writablestream), rather than piping data to it from a [`ReadableStream`](/reference/streams/readablestream). For example:
+A writer is used when you want to write directly to a [`WritableStream`](/reference/runtime-apis/streams/writablestream), rather than piping data to it from a [`ReadableStream`](/reference/runtime-apis/streams/readablestream). For example:
 
 ```js
 function writeArrayToStream(array, writableStream) {
@@ -42,7 +42,7 @@ writeArrayToStream([1, 2, 3, 4, 5], writableStream)
 
 - <Code>abort(reason<ParamType>string</ParamType><PropMeta>optional</PropMeta>)</Code> <Type>Promise&lt;void></Type>
 
-    - Aborts the stream. This method returns a promise that fulfills with a response `undefined`. `reason` is an optional human-readable string indicating the reason for cancellation. `reason` will be passed to the underlying sink's abort algorithm. If this writable stream is one side of a [TransformStream](/reference/streams/transformstream), then its abort algorithm causes the transform's readable side to become errored with `reason`.
+    - Aborts the stream. This method returns a promise that fulfills with a response `undefined`. `reason` is an optional human-readable string indicating the reason for cancellation. `reason` will be passed to the underlying sink's abort algorithm. If this writable stream is one side of a [TransformStream](/reference/runtime-apis/streams/transformstream), then its abort algorithm causes the transform's readable side to become errored with `reason`.
 
     <Aside type="warning" header="Warning">
 

--- a/src/content/reference/runtime-apis/web-crypto.md
+++ b/src/content/reference/runtime-apis/web-crypto.md
@@ -26,7 +26,7 @@ const myDigest = await crypto.subtle.digest(
 console.log(new Uint8Array(myDigest))
 ```
 
-<!-- TODO: Update links to relevant Examples. -->
+<!-- TODO(soon): Link does not exist. Update links to relevant Examples. -->
 Some common uses include:
 
 - [Signing requests.](/reference/write-workers/best-practices/signing-requests)

--- a/src/content/reference/runtime-apis/web-standards.md
+++ b/src/content/reference/runtime-apis/web-standards.md
@@ -62,6 +62,7 @@ The following methods are available per the [Worker Global Scope](https://develo
 
 <Aside>
 
+<!-- TODO(soon): Broken link. -->
 __Note__: Timers are only available inside of [the Request Context](/about/tips/request-context).
 
 </Aside>
@@ -72,12 +73,13 @@ __Note__: Timers are only available inside of [the Request Context](/about/tips/
 
 - <TypeLink href="https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch">fetch()</TypeLink>
 
-  - Starts the process of fetching a resource from the network. See [FetchAPI](/reference/apis/fetch/).
+  - Starts the process of fetching a resource from the network. See [FetchAPI](/reference/runtime-apis/fetch).
 
 </Definitions>
 
 <Aside>
 
+<!-- TODO(soon): Broken link. -->
 __Note__: The Fetch API is only available inside of [the Request Context](/about/tips/request-context).
 
 </Aside>
@@ -100,6 +102,6 @@ The URL API supports urls conforming to http and https schemes.
 
 <Aside>
 
-__Note__: The Workers’ Runtime’s URL class behavior differs from the URL Spec documented above. If you’d like to use another URL implementation, you can [shim the URL class using webpack](/tooling/wrangler/webpack/#shimming-globals).
+__Note__: The Workers’ Runtime’s URL class behavior differs from the URL Spec documented above. If you’d like to use another URL implementation, you can [shim the URL class using webpack](/reference/wrangler-cli/webpack/#shimming-globals).
 
 </Aside>

--- a/src/content/tutorials/authorize-users-with-auth0/index.md
+++ b/src/content/tutorials/authorize-users-with-auth0/index.md
@@ -18,7 +18,7 @@ In this tutorial you’ll integrate Auth0, an identity management platform, into
 
 To publish your Worker to Cloudflare, you’ll need a few things:
 
-- A Cloudflare account, the [Workers Unlimited Plan](/about/pricing), and access to an [API token](/quickstart#api-token) for that account
+- A Cloudflare account, the [Workers Unlimited Plan](/reference/platform/pricing), and access to an [API token](/quickstart#api-token) for that account
 - A Wrangler installation running locally on your machine, and access to the command-line
 - An Auth0 account
 
@@ -97,7 +97,7 @@ export const authorize = async event => {
 }
 ```
 
-The `auth0` object wraps several secrets, which are encrypted values that can be defined and used by your script. In the “Publish” section of this tutorial, we’ll define these secrets using the [`wrangler secret`](https://developers.cloudflare.com/workers/tooling/wrangler/secrets/) command.
+The `auth0` object wraps several secrets, which are encrypted values that can be defined and used by your script. In the “Publish” section of this tutorial, we’ll define these secrets using the [`wrangler secret`](https://developers.cloudflare.com/workers/reference/wrangler-cli/secrets/) command.
 
 The `generateStateParam` function will be used to prevent [Cross-Site Request Forgery attacks](https://auth0.com/docs/protocols/oauth2/mitigate-csrf-attacks). For now, we’ll return a string “stub”, but later in the tutorial, it will generate a random “state” parameter that we’ll store in Workers KV to verify incoming authorization requests.
 
@@ -990,6 +990,6 @@ Congrats! You’ve successfully built an application that authorizes and authent
 
 There’s a lot more that you can build with Workers: serve static and JAMstack-style apps using Workers Sites, transform HTML responses using HTMLRewriter, and more. Here are some more tutorials for you to check out next. Happy coding!
 
-- [Build a Slack bot](/tutorials/build-an-application)
-- [Deploy a React app using Workers Sites](/tutorials/deploy-a-react-app)
+- [Build a Slack bot](/tutorials/build-a-slackbot)
+- [Deploy a React app using Workers Sites](/tutorials/deploy-a-react-app-with-create-react-app)
 - [Localize a website using HTMLRewriter](/tutorials/localize-a-website)

--- a/src/content/tutorials/build-a-jamstack-app/index.md
+++ b/src/content/tutorials/build-a-jamstack-app/index.md
@@ -41,7 +41,7 @@ $ wrangler generate todos
 $ cd todos
 ```
 
-Wrangler templates are just Git repositories, so if you want to create your own templates, or use one from our [Template Gallery](/templates), there’s a ton of options to help you get started.
+Wrangler templates are just Git repositories, so if you want to create your own templates, or use one from our [Template Gallery](/examples), there’s a ton of options to help you get started.
 
 Wrangler’s default template includes support for building and deploying JavaScript-based projects, including Webpack support. Inside of your new `todos` directory, `index.js` represents the entry-point to your Cloudflare Workers application.
 

--- a/src/content/tutorials/build-a-qr-code-generator/index.md
+++ b/src/content/tutorials/build-a-qr-code-generator/index.md
@@ -21,7 +21,7 @@ One more thing before you start the tutorial: if you just want to jump straight 
 To publish your QR Code Generator function to Cloudflare Workers, you’ll need a few things:
 
 - A Cloudflare account, and access to the API keys for that account
-- [A Wrangler installation](/tooling/wrangler/install) running locally on your machine, and access to the command-line
+- [A Wrangler installation](/reference/wrangler-cli/install-update) running locally on your machine, and access to the command-line
 
 If you don’t have those things quite yet, don’t worry. We’ll walk through each of them and make sure we’re ready to go, before you start creating your application.
 
@@ -41,7 +41,7 @@ $ wrangler generate qr-code-generator
 $ cd qr-code-generator
 ```
 
-Wrangler templates are just Git repositories, so if you want to create your own templates, or use one from our [Template Gallery](/templates), there’s a ton of options to help you get started.
+Wrangler templates are just Git repositories, so if you want to create your own templates, or use one from our [Template Gallery](/examples), there’s a ton of options to help you get started.
 
 Cloudflare’s `worker-template` includes support for building and deploying JavaScript-based projects. Inside of your new `qr-code-generator` directory, `index.js` represents the entry-point to your Cloudflare Workers application.
 
@@ -70,7 +70,7 @@ When a `fetch` event comes into the worker, the script uses `event.respondWith` 
 
 ## Build
 
-Any project you publish to Cloudflare Workers can make use of modern JS tooling like ES modules, NPM packages, and [async/await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) functions to put together your application. In addition, simple serverless functions aren’t the only thing you can publish on Cloudflare Workers: you can [build full applications](/tutorials/build-an-application) using the same tooling and process as what we’ll be building today.
+Any project you publish to Cloudflare Workers can make use of modern JS tooling like ES modules, NPM packages, and [async/await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) functions to put together your application. In addition, simple serverless functions aren’t the only thing you can publish on Cloudflare Workers: you can [build full applications](/tutorials/build-a-slackbot) using the same tooling and process as what we’ll be building today.
 
 The QR code generator we’ll build in this tutorial will be a serverless function that runs at a single route and receives requests. Given text sent inside of that request (such as URLs, or strings), the function will encode the text into a QR code, and serve the QR code as a PNG response.
 
@@ -289,6 +289,6 @@ $ wrangler publish
 
 In this tutorial, you built and published a serverless function to Cloudflare Workers for generating QR codes. If you’d like to see the full source code for this application, you can find it [on GitHub](https://github.com/signalnerve/workers-qr-code-generator).
 
-If you want to get started building your own projects, check out the quick-start templates we’ve provided in our [Template Gallery](/templates).
+If you want to get started building your own projects, check out the quick-start templates we’ve provided in our [Template Gallery](/examples).
 
 

--- a/src/content/tutorials/build-a-slackbot/index.md
+++ b/src/content/tutorials/build-a-slackbot/index.md
@@ -70,7 +70,7 @@ When your webhook is created, it will attempt to send a test payload to your app
 
 Cloudflare’s command-line tool for managing Worker projects, Wrangler, has great support for templates — pre-built collections of code that make it easy to get started writing Workers. In this tutorial, you’ll use the [router template](https://github.com/cloudflare/worker-template-router) to generate a Workers project with a built-in router, so you can take incoming requests, and route them to the appropriate JavaScript code.
 
-In the command line, generate your Worker project, passing in a project name (e.g. “slack-bot”), and the [template](/templates) URL to base your project on:
+In the command line, generate your Worker project, passing in a project name (e.g. “slack-bot”), and the [template](/examples) URL to base your project on:
 
 ```sh
 ---
@@ -80,7 +80,7 @@ $ wrangler generate slack-bot https://github.com/cloudflare/worker-template-rout
 $ cd slack-bot
 ```
 
-Wrangler templates are just Git repositories, so if you want to create your own templates, or use one from our [Template Gallery](/templates), there’s a ton of options to help you get started.
+Wrangler templates are just Git repositories, so if you want to create your own templates, or use one from our [Template Gallery](/examples), there’s a ton of options to help you get started.
 
 Cloudflare’s `worker-template` includes support for building and deploying JavaScript-based projects. Inside of your new `slack-bot` directory, `index.js` represents the entry-point to your Cloudflare Workers application.
 
@@ -628,7 +628,7 @@ export default async request => {
 }
 ```
 
-The constant `SLACK_WEBHOOK_URL` represents the Slack Webhook URL that you created all the way back in the “Incoming Webhook” section of this guide. **This webhook allows developers to post directly to your Slack channel, so it should be kept secret!** To use this constant inside of your codebase, you can use Wrangler’s [Secrets](/tooling/wrangler/secrets) feature:
+The constant `SLACK_WEBHOOK_URL` represents the Slack Webhook URL that you created all the way back in the “Incoming Webhook” section of this guide. **This webhook allows developers to post directly to your Slack channel, so it should be kept secret!** To use this constant inside of your codebase, you can use Wrangler’s [Secrets](/reference/wrangler-cli/commands#secret) feature:
 
 ```sh
 ---
@@ -691,6 +691,6 @@ Publishing your Workers application should now cause issue updates to start appe
 
 In this tutorial, you built and published a Cloudflare Workers application that can respond to GitHub webhook events, and allow GitHub API lookups within Slack. If you’d like to see the full source code for this application, you can find the repo [on GitHub](https://github.com/signalnerve/workers-slack-bot).
 
-If you want to get started building your own projects, check out the quick-start templates we’ve provided in our [Template Gallery](/templates).
+If you want to get started building your own projects, check out the quick-start templates we’ve provided in our [Template Gallery](/examples).
 
 

--- a/src/content/tutorials/configure-your-cdn/index.md
+++ b/src/content/tutorials/configure-your-cdn/index.md
@@ -54,7 +54,7 @@ $ wrangler generate serve-cdn-assets
 $ cd serve-cdn-assets
 ```
 
-By default, Wrangler will use our [`worker-template`](https://github.com/cloudflare/worker-template). Wrangler templates are just Git repositories, so if you want to create your own templates, or use one from our [Template Gallery](/templates), there’s a ton of options to help you get started.
+By default, Wrangler will use our [`worker-template`](https://github.com/cloudflare/worker-template). Wrangler templates are just Git repositories, so if you want to create your own templates, or use one from our [Template Gallery](/examples), there’s a ton of options to help you get started.
 
 Cloudflare’s `worker-template` includes support for building and deploying JavaScript-based projects. Inside of your new `serve-cdn-assets` directory, `index.js` represents the entry-point to your Cloudflare Workers application.
 
@@ -83,7 +83,7 @@ When a `fetch` event comes into the worker, the script uses `event.respondWith` 
 
 ## Build
 
-Any project you publish to Cloudflare Workers can make use of modern JS tooling like ES modules, NPM packages, and [async/await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) functions to put together your application. In addition, simple serverless functions aren’t the only thing you can publish on Cloudflare Workers: you can [build full applications](/tutorials/build-an-application), or [serverless functions](/tutorials/build-a-serverless-function) using the same tooling and process as what we’ll be building today.
+Any project you publish to Cloudflare Workers can make use of modern JS tooling like ES modules, NPM packages, and [async/await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) functions to put together your application. In addition, simple serverless functions aren’t the only thing you can publish on Cloudflare Workers: you can [build full applications](/tutorials/build-a-slackbot), or [serverless functions](/tutorials/build-a-qr-code-generator) using the same tooling and process as what we’ll be building today.
 
 The Cloudflare Workers project built in this tutorial will be a serverless function that runs on a _wildcard_ route and receives requests. When the serverless function receives an incoming request, it should parse the URL, find what asset is being requested, and serve it from the configured Cloud Storage bucket. Because the asset will go through your Workers function, and through Cloudflare’s network, you can also make use of both Cloudflare’s _default_ caching behavior, as well as your own custom logic, to ensure that as much data can be cached at Cloudflare’s globally distributed data centers — the result is an easy-to-understand and highly performant CDN configuration, with the ability to customize it to your application’s specific needs.
 
@@ -156,7 +156,7 @@ function serveAsset(event) {
 
 ### Custom caching
 
-At this point in the tutorial, deploying this script would give you a fully-functional project you could use to retrieve assets from your Cloud Storage bucket. Instead of wrapping up the tutorial here, let’s continue to explore how configuring your CDN is really powerful with Workers, by making use of the [Cache API](/about/using-cache).
+At this point in the tutorial, deploying this script would give you a fully-functional project you could use to retrieve assets from your Cloud Storage bucket. Instead of wrapping up the tutorial here, let’s continue to explore how configuring your CDN is really powerful with Workers, by making use of the [Cache API](/learning/how-the-cache-works).
 
 To cache responses in a Workers function, the Cache API provides `cache.match`, to check for the presence of a cached asset, and `cache.put`, to cache a `response` for a given `request`. Given those two functions, the general flow will look like this:
 
@@ -266,6 +266,6 @@ After deploying your project, open up your browser to test retrieving your asset
 In this tutorial, you built and published a serverless function to Cloudflare Workers for serving assets from cloud storage. If you’d like to see the full source code for this application, visit the [repo on GitHub](https://github.com/signalnerve/assets-on-workers).
 
 
-If you want to get started building your own projects, check out the quick-start templates we’ve provided in our [Template Gallery](/templates).
+If you want to get started building your own projects, check out the quick-start templates we’ve provided in our [Template Gallery](/examples).
 
 

--- a/src/content/tutorials/deploy-a-react-app-with-create-react-app/index.md
+++ b/src/content/tutorials/deploy-a-react-app-with-create-react-app/index.md
@@ -111,4 +111,4 @@ After fetching assets from [Workers KV](https://developers.cloudflare.com/worker
 
 In this tutorial, you built and published a static site to Workers. If you’d like to see the full source code for this application, visit the [repo on GitHub](https://github.com/signalnerve/react-workers-template).
 
-If you want to get started building your own projects, check out the quick-start templates we’ve provided in our [Template Gallery](/templates).
+If you want to get started building your own projects, check out the quick-start templates we’ve provided in our [Template Gallery](/examples).

--- a/src/content/tutorials/deploy-a-static-wordpress-site/index.md
+++ b/src/content/tutorials/deploy-a-static-wordpress-site/index.md
@@ -46,7 +46,7 @@ header: Generate a new project
 $ wrangler generate --site wp-static
 ```
 
-the [`--site`](/tooling/wrangler/sites/#commands) flag indicates that we want to deploy a static site, namely, our static WordPress site.
+the [`--site`](/reference/wrangler-cli/sites/#commands) flag indicates that we want to deploy a static site, namely, our static WordPress site.
 
 ### Port the WordPress Site
 

--- a/src/content/tutorials/localize-a-website/index.md
+++ b/src/content/tutorials/localize-a-website/index.md
@@ -5,7 +5,7 @@ difficulty: Intermediate
 
 # Localize a website
 
-The [`HTMLRewriter`](/reference/apis/html-rewriter) class (currently in beta) built into the Cloudflare Workers runtime allows for parsing and rewriting of HTML at the edge, giving developers the ability to efficiently and transparently customize their Workers applications.
+The [`HTMLRewriter`](/reference/runtime-apis/html-rewriter) class (currently in beta) built into the Cloudflare Workers runtime allows for parsing and rewriting of HTML at the edge, giving developers the ability to efficiently and transparently customize their Workers applications.
 
 In this tutorial, we’ll build an example internationalization and localization engine (commonly referred to as “i18n” and “l10n”) for your application, server the content of your site, and automatically translate the content based your visitors’ location in the world.
 
@@ -75,7 +75,7 @@ To start, let’s look at `workers-site/index.js`: our Workers application in th
 
 Inside of this file, the default code for running a [Workers Site](/sites) has been provided. The crucial part of the generated code lives in the `handleEvent` function. The`getAssetFromKV` function retrieves a website asset uploaded from your local `./public` folder, runs some magic to make it live on Workers KV, and returns it to the user. For now, we can ignore much of `getAssetFromKV` (though if you’d like to learn more, check out [the docs](/sites/start-from-worker) .
 
-To implement translations on the site, we’ll take the HTML response retrieved from KV and pass it into a new instance of `HTMLRewriter`. When instantiating `HTMLRewriter`, we can also attach handlers using the `on` function: in our case, we’ll use the `[data-i18n-key]` selector (see the [documentation](/reference/apis/html-rewriter) for more advanced usage) to parse all elements that require translation with a single class, `ElementHandler`. With the created instance of `HTMLRewriter`, the `transform` function takes a `response` and can be returned to the client:
+To implement translations on the site, we’ll take the HTML response retrieved from KV and pass it into a new instance of `HTMLRewriter`. When instantiating `HTMLRewriter`, we can also attach handlers using the `on` function: in our case, we’ll use the `[data-i18n-key]` selector (see the [documentation](/reference/runtime-apis/html-rewriter) for more advanced usage) to parse all elements that require translation with a single class, `ElementHandler`. With the created instance of `HTMLRewriter`, the `transform` function takes a `response` and can be returned to the client:
 
 ```js
 ---
@@ -277,4 +277,4 @@ With that, it’s time to publish your application! Using `wrangler`, we can pub
 
 In this tutorial, you built and published an i18n tool using `HTMLRewriter`. If you’d like to see the full source code for this application, visit the [repo on GitHub](https://github.com/signalnerve/i18n-example-workers).
 
-If you want to get started building your own projects, check out the [templates](/templates).
+If you want to get started building your own projects, check out the [templates](/examples).


### PR DESCRIPTION
Mostly addresses #64 (in fact, I think we should merge this, close #64, and file new tasks for the specific issues I've identified below). 

Specifically, this change fixes all broken non-fragment-URL links that can currently be fixed without importing new content or making meaningful content changes.

I ran the `gatsby-remark-check-links` plugin to identify links. I'm not committing that plugin, because it erroneously identifies _all_ fragment URLs ("anchor links") as broken because of how we use MDX to construct said links.

I did:
* Bulk replaced 13 occurrences of `/templates` with `/examples`
* Bulk replaced 13 occurrences of `/tooling/wrangler` with `/reference/wrangler-cli`
* Bulk replaced 21 occurrences of `/reference/streams` with `/reference/runtime-apis/streams`
* Replaced 3 occurrences of `/tutorials/build-an-application` with `/tutorials/build-a-slackbot`
* Removed trailing slashes from all otherwise-valid links
* Fixed some but not all broken fragment URLs ("anchor links")
* Replaced individual broken links throughout other files one by one, except where noted below (and left many TODOs where I didn’t fix)

I did not:
* Fix links to Examples that don’t exist
* Move over any new content (hence the list of open questions below)
* Check all anchor links

Open questions:
* What replaces `/sites` and `/tooling/wrangler/sites/` ? 
* What replaces `/quickstart` ? 
* What replaces `/reference/storage/*` ? 
* What replaces `/reference/apis/addEventListener/` ? 
* What replaces `/about/tips/request-context` ? 
* We should bring `/about/tips/signing-requests/` in as Examples or a Tutorial, right?