### PR TITLE
Build site to /workers prefix

### DIFF
--- a/bin/postbuild
+++ b/bin/postbuild
@@ -1,0 +1,4 @@
+echo "Moving things into public/workers"
+mv public workers
+mkdir public
+mv workers public

--- a/bin/postbuild
+++ b/bin/postbuild
@@ -1,4 +1,8 @@
-echo "Moving things into public/workers"
+echo "Correcting page-data folder"
+cp -r public/page-data public/workers
+mv public/workers public/page-data
+
+echo "Fixing folder structure to host at /workers"
 mv public workers
 mkdir public
 mv workers public

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -26,7 +26,7 @@ module.exports = {
   },
 
   // Prefix site with /workers
-  pathPrefix: `/workers`,
+  pathPrefix: process.env.NODE_ENV === "production" ? `/workers` : '',
 
   plugins: [
     "gatsby-plugin-sitemap",

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -25,6 +25,10 @@ module.exports = {
     },
   },
 
+  // Prefix site with /workers
+  assetPrefix: `/workers`,
+  pathPrefix: `/workers`,
+
   plugins: [
     "gatsby-plugin-sitemap",
     "gatsby-plugin-eslint",

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -26,7 +26,6 @@ module.exports = {
   },
 
   // Prefix site with /workers
-  assetPrefix: `/workers`,
   pathPrefix: `/workers`,
 
   plugins: [

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -130,7 +130,7 @@ exports.createSchemaCustomization = ({ actions }) => {
     }
 
     type Site {
-      assetPrefix: String
+      pathPrefix: String
     }
   `
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -128,6 +128,10 @@ exports.createSchemaCustomization = ({ actions }) => {
       type: String
       updated: Date @dateformat
     }
+
+    type Site {
+      assetPrefix: String
+    }
   `
 
   createTypes(typeDefs)

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "gatsby build",
+    "build": "npm run clean && gatsby build --prefix-paths",
+    "postbuild": "bin/postbuild",
     "develop": "gatsby develop -H 0.0.0.0",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",

--- a/src/components/docs-search.js
+++ b/src/components/docs-search.js
@@ -1,12 +1,15 @@
 import React, { useEffect } from "react"
 import { navigate } from "@reach/router"
+import { graphql, useStaticQuery } from "gatsby"
 
 import Helmet from "react-helmet"
 
 import DocsTitle from "./docs-title"
 import AccessibleSVG from "./accessible-svg"
 
-const DocsSearch = () => {
+const DEFAULT_PATH_PREFIX = process.env.NODE_ENV !== "production" ? "/workers" : ""
+
+const DocsSearch = ({ pathPrefix }) => {
   useEffect(() => {
     let frames = 0
     const init = () => {
@@ -47,9 +50,9 @@ const DocsSearch = () => {
 
           // Navigate to just the page if the hash points to the h1
           if (page === hash) {
-            navigate(url.pathname)
+            navigate(pathPrefix + url.pathname)
           } else {
-            navigate(url.pathname + url.hash)
+            navigate(pathPrefix + url.pathname + url.hash)
           }
         },
 
@@ -109,4 +112,16 @@ const DocsSearch = () => {
   )
 }
 
-export default DocsSearch
+const DocsSearchWrapper = () => {
+  const { site } = useStaticQuery(graphql`
+    {
+      site {
+        pathPrefix
+      }
+    }
+  `)
+
+  return <DocsSearch pathPrefix={site.pathPrefix || DEFAULT_PATH_PREFIX} />
+}
+
+export default DocsSearchWrapper

--- a/src/components/docs-search.js
+++ b/src/components/docs-search.js
@@ -7,9 +7,7 @@ import Helmet from "react-helmet"
 import DocsTitle from "./docs-title"
 import AccessibleSVG from "./accessible-svg"
 
-const DEFAULT_PATH_PREFIX = process.env.NODE_ENV !== "production" ? "/workers" : ""
-
-const DocsSearch = ({ pathPrefix }) => {
+const DocsSearchContent = ({ pathPrefix }) => {
   useEffect(() => {
     let frames = 0
     const init = () => {
@@ -112,7 +110,7 @@ const DocsSearch = ({ pathPrefix }) => {
   )
 }
 
-const DocsSearchWrapper = () => {
+const DocsSearch = () => {
   const { site } = useStaticQuery(graphql`
     {
       site {
@@ -121,7 +119,7 @@ const DocsSearchWrapper = () => {
     }
   `)
 
-  return <DocsSearch pathPrefix={site.pathPrefix || DEFAULT_PATH_PREFIX} />
+  return <DocsSearchContent pathPrefix={site.pathPrefix} />
 }
 
-export default DocsSearchWrapper
+export default DocsSearch

--- a/src/components/docs-sidebar-nav-item.js
+++ b/src/components/docs-sidebar-nav-item.js
@@ -80,10 +80,7 @@ class DocsSidebarNavItemContent extends React.Component {
     const { pathPrefix, node, location } = this.props
 
     const href = node => pathPrefix ? pathPrefix + node.href : node.href
-    const path = process.env.NODE_ENV === "production" ?
-      location.pathname :
-      pathPrefix + location.pathname
-    const isActive = href(node) === getNormalizedPath(path)
+    const isActive = href(node) === getNormalizedPath(location.pathname)
     const isActiveDueToChild = !this.showChildren() && this.isActiveRoot()
 
     return isActive || isActiveDueToChild
@@ -93,10 +90,7 @@ class DocsSidebarNavItemContent extends React.Component {
     const { pathPrefix, node, location } = this.props
 
     const href = node => pathPrefix ? pathPrefix + node.href : node.href
-    const path = process.env.NODE_ENV === "production" ?
-      location.pathname :
-      pathPrefix + location.pathname
-    const isActive = node => href(node) === getNormalizedPath(path)
+    const isActive = node => href(node) === getNormalizedPath(location.pathname)
     const hasActiveChild = node => !node.children ? false : node.children.some(
       node => isActive(node) || hasActiveChild(node)
     )
@@ -178,7 +172,7 @@ class DocsSidebarNavItemContent extends React.Component {
             <div className={`${collapseClassesBase}content`}>
               <ul className="DocsSidebar--nav-subnav" depth={depth} style={{'--depth': depth}}>
                 {node.children.map(node => (
-                  <DocsSidebarNavItemContent
+                  <DocsSidebarNavItem
                     key={node.id}
                     node={node}
                     location={location}

--- a/src/components/docs-sidebar-nav-item.js
+++ b/src/components/docs-sidebar-nav-item.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { Link } from "gatsby"
+import { graphql, Link, useStaticQuery } from "gatsby"
 
 import Collapse from "@material-ui/core/Collapse"
 
@@ -77,18 +77,26 @@ class DocsSidebarNavItem extends React.Component {
   }
 
   isActive() {
-    const { node, location } = this.props
+    const { assetPrefix, node, location } = this.props
 
-    const isActive = node.href === getNormalizedPath(location.pathname)
+    const path = assetPrefix
+      ? assetPrefix + location.pathname
+      : location.pathname
+
+    const isActive = node.href === getNormalizedPath(path)
     const isActiveDueToChild = !this.showChildren() && this.isActiveRoot()
 
     return isActive || isActiveDueToChild
   }
 
   isActiveRoot() {
-    const { node, location } = this.props
+    const { assetPrefix, node, location } = this.props
 
-    const isActive = node => node.href === getNormalizedPath(location.pathname)
+    const path = assetPrefix
+      ? assetPrefix + location.pathname
+      : location.pathname
+
+    const isActive = node => "/workers" + node.href === getNormalizedPath(path)
     const hasActiveChild = node => !node.children ? false : node.children.some(
       node => isActive(node) || hasActiveChild(node)
     )
@@ -187,4 +195,16 @@ class DocsSidebarNavItem extends React.Component {
   }
 }
 
-export default DocsSidebarNavItem
+const DocsSidebarNavItemWrapper = props => {
+  const { site } = useStaticQuery(graphql`
+    {
+      site {
+        assetPrefix
+      }
+    }
+  `)
+
+  return <DocsSidebarNavItem {...props} assetPrefix={site.assetPrefix} />
+}
+
+export default DocsSidebarNavItemWrapper

--- a/src/components/docs-sidebar-nav-item.js
+++ b/src/components/docs-sidebar-nav-item.js
@@ -10,6 +10,8 @@ import userPrefersReducedMotion from "../utils/user-prefers-reduced-motion"
 
 const collapseClassesBase = "DocsSidebar--nav-item-collapse-"
 
+const DEFAULT_PATH_PREFIX = process.env.NODE_ENV !== "production" ? "/workers" : ""
+
 const DocsSidebarCollapse = ({ expanded, children }) => {
   const base = collapseClassesBase
   const collapseClasses = {
@@ -79,13 +81,11 @@ class DocsSidebarNavItem extends React.Component {
   isActive() {
     const { pathPrefix, node, location } = this.props
 
-    const path = pathPrefix
-      ? pathPrefix + location.pathname
-      : location.pathname
-
-    console.log(pathPrefix + node.href)
-    console.log(pathPrefix + location.pathname)
-    const isActive = pathPrefix + node.href === getNormalizedPath(path)
+    const href = node => pathPrefix ? pathPrefix + node.href : node.href
+    const path = process.env.NODE_ENV === "production" ?
+      location.pathname :
+      pathPrefix + location.pathname
+    const isActive = href(node) === getNormalizedPath(path)
     const isActiveDueToChild = !this.showChildren() && this.isActiveRoot()
 
     return isActive || isActiveDueToChild
@@ -94,11 +94,11 @@ class DocsSidebarNavItem extends React.Component {
   isActiveRoot() {
     const { pathPrefix, node, location } = this.props
 
-    const path = pathPrefix
-      ? pathPrefix + location.pathname
-      : location.pathname
-
-    const isActive = node => pathPrefix + node.href === getNormalizedPath(path)
+    const href = node => pathPrefix ? pathPrefix + node.href : node.href
+    const path = process.env.NODE_ENV === "production" ?
+      location.pathname :
+      pathPrefix + location.pathname
+    const isActive = node => href(node) === getNormalizedPath(path)
     const hasActiveChild = node => !node.children ? false : node.children.some(
       node => isActive(node) || hasActiveChild(node)
     )
@@ -206,7 +206,7 @@ const DocsSidebarNavItemWrapper = props => {
     }
   `)
 
-  return <DocsSidebarNavItem {...props} pathPrefix={site.pathPrefix} />
+  return <DocsSidebarNavItem {...props} pathPrefix={site.pathPrefix || DEFAULT_PATH_PREFIX} />
 }
 
 export default DocsSidebarNavItemWrapper

--- a/src/components/docs-sidebar-nav-item.js
+++ b/src/components/docs-sidebar-nav-item.js
@@ -77,26 +77,28 @@ class DocsSidebarNavItem extends React.Component {
   }
 
   isActive() {
-    const { assetPrefix, node, location } = this.props
+    const { pathPrefix, node, location } = this.props
 
-    const path = assetPrefix
-      ? assetPrefix + location.pathname
+    const path = pathPrefix
+      ? pathPrefix + location.pathname
       : location.pathname
 
-    const isActive = node.href === getNormalizedPath(path)
+    console.log(pathPrefix + node.href)
+    console.log(pathPrefix + location.pathname)
+    const isActive = pathPrefix + node.href === getNormalizedPath(path)
     const isActiveDueToChild = !this.showChildren() && this.isActiveRoot()
 
     return isActive || isActiveDueToChild
   }
 
   isActiveRoot() {
-    const { assetPrefix, node, location } = this.props
+    const { pathPrefix, node, location } = this.props
 
-    const path = assetPrefix
-      ? assetPrefix + location.pathname
+    const path = pathPrefix
+      ? pathPrefix + location.pathname
       : location.pathname
 
-    const isActive = node => "/workers" + node.href === getNormalizedPath(path)
+    const isActive = node => pathPrefix + node.href === getNormalizedPath(path)
     const hasActiveChild = node => !node.children ? false : node.children.some(
       node => isActive(node) || hasActiveChild(node)
     )
@@ -178,7 +180,7 @@ class DocsSidebarNavItem extends React.Component {
             <div className={`${collapseClassesBase}content`}>
               <ul className="DocsSidebar--nav-subnav" depth={depth} style={{'--depth': depth}}>
                 {node.children.map(node => (
-                  <DocsSidebarNavItem
+                  <DocsSidebarNavItemWrapper
                     key={node.id}
                     node={node}
                     location={location}
@@ -199,12 +201,12 @@ const DocsSidebarNavItemWrapper = props => {
   const { site } = useStaticQuery(graphql`
     {
       site {
-        assetPrefix
+        pathPrefix
       }
     }
   `)
 
-  return <DocsSidebarNavItem {...props} assetPrefix={site.assetPrefix} />
+  return <DocsSidebarNavItem {...props} pathPrefix={site.pathPrefix} />
 }
 
 export default DocsSidebarNavItemWrapper

--- a/src/components/docs-sidebar-nav-item.js
+++ b/src/components/docs-sidebar-nav-item.js
@@ -10,8 +10,6 @@ import userPrefersReducedMotion from "../utils/user-prefers-reduced-motion"
 
 const collapseClassesBase = "DocsSidebar--nav-item-collapse-"
 
-const DEFAULT_PATH_PREFIX = process.env.NODE_ENV !== "production" ? "/workers" : ""
-
 const DocsSidebarCollapse = ({ expanded, children }) => {
   const base = collapseClassesBase
   const collapseClasses = {
@@ -59,7 +57,7 @@ const DocsSidebarCollapse = ({ expanded, children }) => {
   )
 }
 
-class DocsSidebarNavItem extends React.Component {
+class DocsSidebarNavItemContent extends React.Component {
 
   constructor(props) {
     super(props)
@@ -180,7 +178,7 @@ class DocsSidebarNavItem extends React.Component {
             <div className={`${collapseClassesBase}content`}>
               <ul className="DocsSidebar--nav-subnav" depth={depth} style={{'--depth': depth}}>
                 {node.children.map(node => (
-                  <DocsSidebarNavItemWrapper
+                  <DocsSidebarNavItemContent
                     key={node.id}
                     node={node}
                     location={location}
@@ -197,7 +195,7 @@ class DocsSidebarNavItem extends React.Component {
   }
 }
 
-const DocsSidebarNavItemWrapper = props => {
+const DocsSidebarNavItem = props => {
   const { site } = useStaticQuery(graphql`
     {
       site {
@@ -206,7 +204,7 @@ const DocsSidebarNavItemWrapper = props => {
     }
   `)
 
-  return <DocsSidebarNavItem {...props} pathPrefix={site.pathPrefix || DEFAULT_PATH_PREFIX} />
+  return <DocsSidebarNavItemContent {...props} pathPrefix={site.pathPrefix} />
 }
 
-export default DocsSidebarNavItemWrapper
+export default DocsSidebarNavItem


### PR DESCRIPTION
Build gatsby application and run a postbuild step to nest every URL to `/workers`.  This has been tested on
https://workers-docs.cloudflare-docs.workers.dev, and I've verified that the `sitemap.xml` file generated by Gatsby also nests URLs correctly.

BTW, this is a simplified version of what we have in https://github.com/cloudflare/workers-docs 👍 