### PR TITLE
Support for adding a `pathPrefix` via `gatsby-config.js`

### DIFF
--- a/bin/postbuild
+++ b/bin/postbuild
@@ -1,0 +1,8 @@
+echo "Correcting page-data folder"
+cp -r public/page-data public/workers
+mv public/workers public/page-data
+
+echo "Fixing folder structure to host at /workers"
+mv public workers
+mkdir public
+mv workers public

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,4 +1,9 @@
 module.exports = {
+  // Deploy production site to /workers but keep
+  // local development done at the root due to:
+  // https://github.com/gatsbyjs/gatsby/issues/16040
+  pathPrefix: process.env.NODE_ENV === "production" ? "/workers" : "",
+
   siteMetadata: {
     title: "Cloudflare Docs",
     description: "Documentation for Cloudflare products and services.",

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -128,6 +128,10 @@ exports.createSchemaCustomization = ({ actions }) => {
       type: String
       updated: Date @dateformat
     }
+
+    type Site {
+      pathPrefix: String
+    }
   `
 
   createTypes(typeDefs)

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "gatsby build",
+    "build": "npm run clean && gatsby build --prefix-paths",
+    "postbuild": "bin/postbuild",
     "develop": "gatsby develop -H 0.0.0.0",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",

--- a/src/components/docs-search.js
+++ b/src/components/docs-search.js
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react"
 import { navigate } from "@reach/router"
+import getPathPrefix from "../utils/get-path-prefix"
 
 import Helmet from "react-helmet"
 
@@ -41,15 +42,31 @@ const DocsSearch = () => {
         handleSelected: (input, event, suggestion, datasetNumber, context) => {
           const url = new URL(suggestion.url)
 
-          const folders = url.pathname.split("/")
-          const page = folders[folders.length - 1]
-          const hash = url.hash.slice(1)
+          // TODO: remove after Algolia crawls the pathPrefixed site
+          const pathPrefix = getPathPrefix()
+          const pathname =
+            url.pathname.startsWith(`${pathPrefix}/`) ?
+              url.pathname :
+              pathPrefix + url.pathname
 
-          // Navigate to just the page if the hash points to the h1
-          if (page === hash) {
-            navigate(url.pathname)
+          if (suggestion.isLvl0) {
+            // Don’t scroll to hash when it’s just the h1.
+            navigate(pathname)
+
           } else {
-            navigate(url.pathname + url.hash)
+            // When search results also scroll to hash,
+            // blur the input so it’s not confusing that
+            // your focus is still up in the search, and
+            // also clear the input for next use.
+            search.input[0].blur()
+            search.input[0].value = ""
+            navigate(pathname + url.hash)
+
+            // Then focus the anchor in the header anchor
+            // corresponding to the hash if it exists (it
+            // should if Algolia’s crawl is up-to-date).
+            const headerAnchor = document.querySelector(`${url.hash} a`)
+            if (headerAnchor) headerAnchor.focus()
           }
         },
 

--- a/src/components/docs-sidebar-nav-item.js
+++ b/src/components/docs-sidebar-nav-item.js
@@ -5,6 +5,7 @@ import Collapse from "@material-ui/core/Collapse"
 
 import sidebarCollapseTransitionDuration from "../constants/sidebar-collapse-transition-duration"
 
+import getPathPrefix from "../utils/get-path-prefix"
 import getNormalizedPath from "../utils/get-normalized-path"
 import userPrefersReducedMotion from "../utils/user-prefers-reduced-motion"
 
@@ -57,6 +58,8 @@ const DocsSidebarCollapse = ({ expanded, children }) => {
   )
 }
 
+const pathPrefix = getPathPrefix()
+
 class DocsSidebarNavItem extends React.Component {
 
   constructor(props) {
@@ -79,7 +82,8 @@ class DocsSidebarNavItem extends React.Component {
   isActive() {
     const { node, location } = this.props
 
-    const isActive = node.href === getNormalizedPath(location.pathname)
+    const href = pathPrefix ? pathPrefix + node.href : node.href
+    const isActive = href === getNormalizedPath(location.pathname)
     const isActiveDueToChild = !this.showChildren() && this.isActiveRoot()
 
     return isActive || isActiveDueToChild
@@ -88,7 +92,8 @@ class DocsSidebarNavItem extends React.Component {
   isActiveRoot() {
     const { node, location } = this.props
 
-    const isActive = node => node.href === getNormalizedPath(location.pathname)
+    const href = node => pathPrefix ? pathPrefix + node.href : node.href
+    const isActive = node => href(node) === getNormalizedPath(location.pathname)
     const hasActiveChild = node => !node.children ? false : node.children.some(
       node => isActive(node) || hasActiveChild(node)
     )

--- a/src/components/mdx/anchor-link.js
+++ b/src/components/mdx/anchor-link.js
@@ -1,6 +1,7 @@
 import React from "react"
 import { Link } from "gatsby"
 import { navigate } from "@reach/router"
+import getPathPrefix from "../../utils/get-path-prefix"
 
 import { className } from "./root"
 import IconExternalLink from "../icons/external-link"
@@ -32,6 +33,21 @@ export default ({ href, className, children, ...props }) => {
       const link = event.target.closest("a")
       event.preventDefault()
       navigate(link.href)
+    }
+  }
+
+  if (!useRegularLink) {
+    // Unfortunately, MDX seems to be automatically prefixing[1]
+    // the href with the `pathPrefix`[2] before we get access to
+    // it here. Gatsby’s `<Link/>` component below also prefixes
+    // it, so we strip the prefix here first so that it doesn’t
+    // end up getting double-prefixed.
+    // [1] https://git.io/JJNPs
+    // [2] https://www.gatsbyjs.com/docs/path-prefix/
+    const pathPrefix = getPathPrefix()
+
+    if (href.startsWith(`${pathPrefix}/`)) {
+      href = href.substr(pathPrefix.length)
     }
   }
 

--- a/src/utils/get-path-prefix.js
+++ b/src/utils/get-path-prefix.js
@@ -1,0 +1,14 @@
+import { withPrefix } from "gatsby"
+
+// Gatsby’s `<Link/>` component automatically applies the
+// `pathPrefix` set in gatsby-config.js. However when
+// constructing URLs manually, it can be useful to have
+// direct access to the `pathPrefix`. Gatsby offers a
+// method `withPrefix()` for this purpose, but this still
+// doesn’t give you direct access to the value. Here, we
+// "trick" `withPrefix` to giving us the value by passing
+// in "/" and then trimming the "/" off of the end. Sadly
+// you can’t just call `withPrefix("")` because that
+// somewhat surprisingly returns "".
+// See: https://www.gatsbyjs.com/docs/path-prefix/
+export default () => withPrefix("/").slice(0, -1)


### PR DESCRIPTION
Closes https://github.com/cloudflare/workers-docs-engine/issues/156, supersedes https://github.com/cloudflare/workers-docs-engine/pull/152.

See: https://www.gatsbyjs.com/docs/path-prefix/

Demo: https://workers-path-prefix-testing.cloudflaredocs.workers.dev/workers/