### PR TITLE
Bump lilredirector and fix baseUrl

### DIFF
--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -37,6 +37,7 @@ async function handleEvent(event) {
 
   try {
     const { response } = await redirector(event, {
+      baseUrl: '/workers/_redirects',
       validateRedirects: false
     })
     if (response) return response

--- a/workers-site/package-lock.json
+++ b/workers-site/package-lock.json
@@ -24,11 +24,20 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.2.tgz",
       "integrity": "sha512-4kPlzbljFcsttWEq6aBW0OZe6BDajAmyvr2xknBG92tejQnvdGtT9+kXSZ580DqpxY9qG2xeQVF9Dq0ymUTo5Q=="
     },
-    "lilredirector": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/lilredirector/-/lilredirector-0.2.2.tgz",
-      "integrity": "sha512-XvQYFdiNVRQIzwzXA2qUht8wdok8wcG9mKRSNFMEzQlJoyqLVCqTqBG7rW8V74v2mtsyKfOKrtVFheT8kv4oZg==",
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
       "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "lilredirector": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/lilredirector/-/lilredirector-0.3.0.tgz",
+      "integrity": "sha512-OviMzyfqgQMYpf65fVviHeSoRfWd0bsZOzysNQGCR6W33HsbcAJ/uZZf3bAjtjklnMZyGV2oUNoeZUgF4RxA/A==",
+      "requires": {
+        "basic-auth": "^2.0.1",
         "papaparse": "^5.2.0"
       }
     },
@@ -41,6 +50,11 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.2.0.tgz",
       "integrity": "sha512-ylq1wgUSnagU+MKQtNeVqrPhZuMYBvOSL00DHycFTCxownF95gpLAk1HiHdUW77N8yxRq1qHXLdlIPyBSG9NSA=="
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     }
   }
 }

--- a/workers-site/package.json
+++ b/workers-site/package.json
@@ -8,6 +8,6 @@
   "license": "MIT",
   "dependencies": {
     "@cloudflare/kv-asset-handler": "^0.0.11",
-    "lilredirector": "0.2.2"
+    "lilredirector": "0.3.0"
   }
 }


### PR DESCRIPTION
Bump lilredirector to 0.3.0, and set the baseUrl (new in 0.3.0) to `/workers/_redirects`