### PR TITLE
Update path to 404.html

### DIFF
--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -54,7 +54,7 @@ async function handleEvent(event) {
     if (!DEBUG) {
       try {
         let notFoundResponse = await getAssetFromKV(event, {
-          mapRequestToAsset: req => new Request(`${new URL(req.url).origin}/404.html`, req),
+          mapRequestToAsset: req => new Request(`${new URL(req.url).origin}/workers/404.html`, req),
         })
 
         return new Response(notFoundResponse.body, { ...notFoundResponse, status: 404 })


### PR DESCRIPTION
Fixes #166 .

My hypothesis is that we're looking up https://developers.cloudflare.com/404.html in our asset manifest and failing to find it, when we should be looking up https://developers.cloudflare.com/workers/404.html instead.



I'm not sure how best to test this.