### PR TITLE
New `docs-config.js` to re-use `pathPrefix` between Workers Sites and Gataby config

### DIFF
--- a/docs-config.js
+++ b/docs-config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  pathPrefix: "/workers",
+}

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,8 +1,12 @@
+const docsConfig = require("./docs-config.js")
+
+const isProduction = process.env.NODE_ENV === "production"
+
 module.exports = {
-  // Deploy production site to /workers but keep
-  // local development done at the root due to:
+  // Deploy production site to the docs config pathPrefix
+  // but keep local development done at the root due to:
   // https://github.com/gatsbyjs/gatsby/issues/16040
-  pathPrefix: process.env.NODE_ENV === "production" ? "/workers" : "",
+  pathPrefix: isProduction ? docsConfig.pathPrefix : "",
 
   siteMetadata: {
     title: "Cloudflare Docs",

--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -1,6 +1,8 @@
 import { getAssetFromKV, mapRequestToAsset } from '@cloudflare/kv-asset-handler'
 import redirector from 'lilredirector'
 
+const docsConfig = require("../docs-config.js")
+
 /**
  * The DEBUG flag will do two things that help during development:
  * 1. we will skip caching on the edge, which makes it easier to
@@ -9,11 +11,6 @@ import redirector from 'lilredirector'
  *    than the default 404.html page.
  */
 const DEBUG = false
-
-// TODO:
-// This and the same variable in gatsby-config.js
-// should pull from the same location.
-const pathPrefix = '/workers'
 
 addEventListener('fetch', event => {
   try {
@@ -42,7 +39,7 @@ async function handleEvent(event) {
 
   try {
     const { response } = await redirector(event, {
-      baseUrl: `${pathPrefix}/_redirects`,
+      baseUrl: `${docsConfig.pathPrefix}/_redirects`,
       validateRedirects: false
     })
     if (response) return response
@@ -59,7 +56,7 @@ async function handleEvent(event) {
     if (!DEBUG) {
       try {
         let notFoundResponse = await getAssetFromKV(event, {
-          mapRequestToAsset: req => new Request(`${new URL(req.url).origin}${pathPrefix}/404.html`, req),
+          mapRequestToAsset: req => new Request(`${new URL(req.url).origin}${docsConfig.pathPrefix}/404.html`, req),
         })
 
         return new Response(notFoundResponse.body, { ...notFoundResponse, status: 404 })


### PR DESCRIPTION
Theoretical mockup (WIP, untested).