### PR TITLE
request.cf.metroCode is a string

### DIFF
--- a/src/content/runtime-apis/request.md
+++ b/src/content/runtime-apis/request.md
@@ -239,7 +239,7 @@ In addition to the properties on the standard [`Request`](https://developer.mozi
 
   - Postal code of the incoming request, e.g. `"78701"`.
 
-- `metroCode` <Type>number | null</Type>
+- `metroCode` <Type>string | null</Type>
 
   - Metro code (DMA) of the incoming request, e.g. `"635"`.
 


### PR DESCRIPTION
As far as I can tell `request.cf.metroCode` is actually a string, as shown in the example. We're seeing it as a string in practice.