### PR TITLE
Fix bug in cache-api example

### DIFF
--- a/src/content/examples/cache-api.md
+++ b/src/content/examples/cache-api.md
@@ -86,7 +86,7 @@ async function handlePostRequest(event) {
   // Otherwise, fetch response to POST request from origin
   if (!response) {
     response = await fetch(request)
-    event.waitUntil(cache.put(cacheKey, response))
+    event.waitUntil(cache.put(cacheKey, response.clone()))
   }
   return response
 }


### PR DESCRIPTION
Cache API example currently errors for POST requests with:

**Uncaught (in response) TypeError: Body has already been used. It can only be used once. Use tee() first if you need to read it twice.**

This modification fixes and closes #170 