### PR TITLE
unused code on redirect example

### DIFF
--- a/src/content/examples/redirect.md
+++ b/src/content/examples/redirect.md
@@ -20,7 +20,6 @@ const destinationURL = "https://example.com"
 const statusCode = 301
 
 async function handleRequest(request) {
-  const { pathname } = new URL(request.url)
   return Response.redirect(destinationURL, statusCode)
 }
 


### PR DESCRIPTION
removed line of code that is not used when running the example.