### PR TITLE
Fix typo in dev upstream-protocol option

### DIFF
--- a/src/content/cli-wrangler/commands.md
+++ b/src/content/cli-wrangler/commands.md
@@ -207,7 +207,7 @@ $ wrangler dev [--env $ENVIRONMENT_NAME] [--ip <ip>] [--port <port>] [--host <ho
 - `--local-protocol` <PropMeta>optional</PropMeta>
   - Protocol to listen to requests on, defaults to http.
 
-- `--upstream-protocl` <PropMeta>optional</PropMeta>
+- `--upstream-protocol` <PropMeta>optional</PropMeta>
   - Protocol to forward requests to host on, defaults to https.
 
 </Definitions>


### PR DESCRIPTION
This PR fixes the following typo in wrangler commands doc.

![Screen Shot 2020-09-01 at 18 14 29](https://user-images.githubusercontent.com/5674762/91851492-fc3b4a80-ec7e-11ea-9920-c68764d28f00.png)
