### PR TITLE
Specify edgeTTL of 5 seconds

### DIFF
--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -49,6 +49,12 @@ async function handleEvent(event) {
       options.cacheControl = {
         bypassCache: true,
       }
+    } else {
+      options.cacheControl = {
+        browserTTL: null,
+        edgeTTL: 5,
+        bypassCache: false,
+      }
     }
     return await getAssetFromKV(event, options)
   } catch (e) {


### PR DESCRIPTION
We're seeing occasional stale reads after deploys, because we're caching old versions of `index.html`, which include links to `js` bundles that are deleted upon a new deployment / no longer exist in the asset manifest upon a new deployment.