### PR TITLE
Fix incorrect `wrangler secret` command example

### DIFF
--- a/src/content/platform/environments.md
+++ b/src/content/platform/environments.md
@@ -258,7 +258,7 @@ vars = {FOO = "some text"}
 
 <Aside>
 
-__Note:__ Secret variables can only be assigned to specific environments by passing the `-e/--env <environment_name>` flag while using the [`wrangler secret create`](/cli-wrangler/commands#secret) command.
+__Note:__ Secret variables can only be assigned to specific environments by passing the `-e/--env <environment_name>` flag while using the [`wrangler secret put`](/cli-wrangler/commands#secret) command.
 
 </Aside>
 


### PR DESCRIPTION
A code snippet incorrectly references a nonexistent command  `wrangler secret create`. This should be `wrangler secret put`.