### PR TITLE
KV limits error on plan

### DIFF
--- a/src/content/platform/limits.md
+++ b/src/content/platform/limits.md
@@ -26,15 +26,15 @@ order: 2
 
 <TableWrap>
 
-| Feature                               | Free       | Bundled    |
-|---------------------------------------|------------|------------|
-| [Reads/second](#kv)                   | unlimited  | unlimited  |
-| [Writes/second (different keys)](#kv) | unlimited  | unlimited  |
-| [Writes/second (same key)](#kv)       | 1          | 1          |
-| [Namespaces](#kv)                     | 100        | 100        |
-| [Keys/namespace](#kv)                 | unlimited  | unlimited  |
-| [Key size](#kv)                       | 512 bytes  | 512 bytes  |
-| [Key metadata](#kv)                   | 1024 bytes | 1024 bytes |
+| Feature                               | Bundled    |
+|---------------------------------------|------------|
+| [Reads/second](#kv)                   | unlimited  |
+| [Writes/second (different keys)](#kv) | unlimited  |
+| [Writes/second (same key)](#kv)       | 1          |
+| [Namespaces](#kv)                     | 100        |
+| [Keys/namespace](#kv)                 | unlimited  |
+| [Key size](#kv)                       | 512 bytes  |
+| [Key metadata](#kv)                   | 1024 bytes |
 
 </TableWrap>
 


### PR DESCRIPTION
KV is not available on Free plans.

Reference text at the bottom and CF pricing plans.: "After subscription to a Workers Bundled plan..."
