### PR TITLE
remove obsolete feedback-link for `workers dev`

### DIFF
--- a/src/content/cli-wrangler/commands.md
+++ b/src/content/cli-wrangler/commands.md
@@ -227,8 +227,6 @@ $ wrangler dev
 
 From here you can send HTTP requests to `localhost:8787` and your Worker should execute as expected. You will also see console.log messages and exceptions appearing in your terminal. If either of these things _don’t_ happen, or you think the output is incorrect, please [file an issue](https://github.com/cloudflare/wrangler).
 
-We’d love [your feedback and questions](https://github.com/cloudflare/wrangler/issues/1047) about `wrangler dev`.
-
 ### kv_namespaces
 
 If you are using [kv_namespaces](/cli-wrangler/configuration#kv_namespaces) with `wrangler dev`, you will need to specify a `preview_id` in your `wrangler.toml` before you can start the session. This is so that you do not accidentally write changes to your production namespace while you are developing. You may make `preview_id` equal to `id` if you would like to preview with your production namespace, but you should make sure that you are not writing things to KV that would break your production Worker.


### PR DESCRIPTION
the feedback issue has been closed a few days ago (see https://github.com/cloudflare/wrangler/issues/1047#issuecomment-678668699), therefore this link does no longer provide a benefit to readers of the documentation.

Alternatively it would also be an option to change the link to something else, for example a link to the [issues overview page](https://github.com/cloudflare/wrangler/issues) but it might be confusing and/or might be better suited at a more central place rather then just for this paragraph / section.