### PR TITLE
Corrected spelling error

### DIFF
--- a/src/content/platform/languages.md
+++ b/src/content/platform/languages.md
@@ -49,7 +49,7 @@ JavaScript is fully supported on the Workers platform. We recommend using JavaSc
 
 ## Compiled to JavaScript
 
-You can also implement Workers with any language than can compile to JavaScript, including the languages below. Learn more by checking out the example projects.
+You can also implement Workers with any language that can compile to JavaScript, including the languages below. Learn more by checking out the example projects.
 
 <TableWrap>
 


### PR DESCRIPTION
Hi, on line 52, I corrected "implement Workers with any language 𝘁𝗵𝗮𝗻 can compile to JavaScript" to "implement Workers with any language 𝘁𝗵𝗮𝘁 can compile to JavaScript".

This is my first pull request so please let me know if I made any mistakes. Thank you.