### PR TITLE
fix: Incorrect command name

### DIFF
--- a/src/content/cli-wrangler/commands.md
+++ b/src/content/cli-wrangler/commands.md
@@ -848,7 +848,7 @@ yes
 Writes a file full of key/value pairs to the given namespace.
 
 ```sh
-$ wrangler kv:key put --binding= [--env=] [--preview] [--namespace-id=] $FILENAME
+$ wrangler kv:bulk put --binding= [--env=] [--preview] [--namespace-id=] $FILENAME
 ```
 
 <Definitions>


### PR DESCRIPTION
The example for BULK is actually calling the command `kv:key ` instead of `kv:bulk`