### PR TITLE
example: add `Access-Control-Max-Age` header to cors-header-proxy

### DIFF
--- a/src/content/examples/cors-header-proxy.md
+++ b/src/content/examples/cors-header-proxy.md
@@ -23,6 +23,7 @@ const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "GET, HEAD, POST, OPTIONS",
   "Access-Control-Allow-Headers": "Content-Type",
+  "Access-Control-Max-Age": "86400",
 }
 
 // The URL for the remote third party API you want to fetch from


### PR DESCRIPTION
No need to make the client send an options for every request. From my experience the worker can start demonstrating strange behavior like sending empty response bodies on a POST if too many OPTIONS requests are coming in. I have no reproducible example but this should be a helpful addition regardless.

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age for the magic number