### PR TITLE
Revert environment variable size limit to 1kb

### DIFF
--- a/src/content/platform/limits.md
+++ b/src/content/platform/limits.md
@@ -131,7 +131,7 @@ If the system detects that a Worker is deadlocked on open connections — for in
 The maximum number of environment variables (secret and text combined) for a Worker is 32 variables.
 There is no limit to the number of environment variables per account.
 
-Each environment variable has a size limitation of 5 KiB.
+Each environment variable has a size limitation of 1 KiB.
 
 ### Script size
 


### PR DESCRIPTION
It appears we updated our documented limit to 5kb before we actually finished implementing the new limit. Reported here: https://community.cloudflare.com/t/introducing-secrets-and-environment-variables-to-cloudflare-workers/152016/15