### PR TITLE
Remove extra 'or' from dev --host help text

### DIFF
--- a/src/content/cli-wrangler/commands.md
+++ b/src/content/cli-wrangler/commands.md
@@ -202,7 +202,7 @@ $ wrangler dev [--env $ENVIRONMENT_NAME] [--ip <ip>] [--port <port>] [--host <ho
   - Port to listen on, defaults to 8787
 
 - `--host` <PropMeta>optional</PropMeta>
-  - Host to forward or requests to, defaults to the zone of project or to tutorial.cloudflareworkers.com if unauthenticated.
+  - Host to forward requests to, defaults to the zone of project or to tutorial.cloudflareworkers.com if unauthenticated.
 
 - `--local-protocol` <PropMeta>optional</PropMeta>
   - Protocol to listen to requests on, defaults to http.


### PR DESCRIPTION
Tiny fix. This PR removes an extra "or" from the `wrangler dev` command `--host` argument's help text. This reflects the change requested in the CLI, issue https://github.com/cloudflare/wrangler/issues/1545 fixed in PR https://github.com/cloudflare/wrangler/pull/1564.