### PR TITLE
Remove dark-mode specific shadow height

### DIFF
--- a/src/css/docs/components/docs-sidebar.css
+++ b/src/css/docs/components/docs-sidebar.css
@@ -300,7 +300,6 @@ https://bugs.chromium.org/p/chromium/issues/detail?id=997607
 [theme="dark"] .DocsSidebar--nav-section-shadow {
   box-shadow: inset 0 1px rgba(var(--shadow-color-rgb), .5);
   background: linear-gradient(rgba(var(--shadow-color-rgb), .2), transparent);
-  height: .5em;
   border-top: 1px solid #222;
 }
 


### PR DESCRIPTION
The shadow has an explicit 0.5em height in dark mode, but not in light mode, which falls back to the 0.25em set upstream in the cascade.

If we want to maintain the height in dark mode, we should also set it to be the same in light mode too

![image](https://user-images.githubusercontent.com/5633704/147394639-78a0b3f2-e70d-49e9-b51b-22bb9d966477.png)

![image](https://user-images.githubusercontent.com/5633704/147394640-d0033798-8e10-4440-b813-a7d3c2873103.png)


When the user rapidly changes between dark and light mode, the layout shifts noticeably. Try holding shift+D on [the docs page](https://developers.cloudflare.com/images/cloudflare-images/serve-images) to see it in effect